### PR TITLE
Spawn slave nodes for clustered tests

### DIFF
--- a/test/support/cluster.ex
+++ b/test/support/cluster.ex
@@ -1,0 +1,59 @@
+defmodule Phoenix.PubSub.Cluster do
+  def spawn do
+    # Turn node into a distributed node with the given long name
+    :net_kernel.start([:"master@127.0.0.1"])
+
+    # Allow slave nodes to fetch all code from this node
+    :erl_boot_server.start([])
+    allow_boot to_char_list("127.0.0.1")
+
+    # Start configured nodes as slaves
+    Application.get_env(:phoenix_pubsub, :nodes, [])
+    |> Enum.each(&(spawn_node(&1)))
+  end
+
+  defp spawn_node(node_host) do
+    {:ok, slave} = :slave.start(to_char_list("127.0.0.1"), node_name(node_host), inet_loader_args)
+    add_code_paths(slave)
+    transfer_configuration(slave)
+    ensure_applications_started(slave)
+    {:ok, slave}
+  end
+
+  defp rpc(slave, module, method, args) do
+    :rpc.block_call(slave, module, method, args)
+  end
+
+  defp inet_loader_args do
+    "-loader inet -hosts 127.0.0.1 -setcookie #{:erlang.get_cookie}" |> to_char_list
+  end
+
+  defp allow_boot(host) do
+    {:ok, ipv4} = :inet.parse_ipv4_address(host)
+    :erl_boot_server.add_slave(ipv4)
+  end
+
+  defp add_code_paths(slave) do
+    :rpc.block_call(slave, :code, :add_paths, [:code.get_path])
+  end
+
+  defp transfer_configuration(slave) do
+    Application.get_all_env(:phoenix_pubsub) |> Enum.each(fn({config_key, config_value}) ->
+      rpc(slave, Application, :put_env, [:phoenix_pubsub, config_key, config_value])
+    end)
+  end
+
+  defp ensure_applications_started(slave) do
+    Enum.each Application.loaded_applications, fn({app_name, _, _}) ->
+      rpc(slave, :application, :ensure_all_started, [app_name])
+    end
+  end
+
+  defp node_name(node_host) do
+    node_host
+    |> to_string
+    |> String.split("@")
+    |> Enum.at(0)
+    |> String.to_atom
+  end
+end

--- a/test/support/node_case.ex
+++ b/test/support/node_case.ex
@@ -1,21 +1,12 @@
 defmodule Phoenix.PubSub.NodeCase do
 
-  @timeout 100
+  @timeout 250
 
   defmacro __using__(_opts) do
     quote do
       use ExUnit.Case, async: false
       import unquote(__MODULE__)
       @moduletag :clustered
-    end
-  end
-
-  def connect_and_recompile(node) do
-    if Node.connect(node) do
-      case call_node(node, fn -> IEx.Helpers.recompile() end) do
-        {_pid, {:restarted, [:phoenix_pubsub]}} -> true
-        _ -> false
-      end
     end
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -4,20 +4,6 @@ cond do
   :clustered in exclude ->
     ExUnit.start()
   true ->
-    :net_kernel.start([:"master@127.0.0.1"])
-    nodes = Application.get_env(:phoenix_pubsub, :nodes, [])
-
-    if Enum.all?(nodes, &Phoenix.PubSub.NodeCase.connect_and_recompile(&1) == true) do
-      ExUnit.start()
-    else
-      IO.write :stderr, """
-      Unable to connect to test nodes. To run distributed tests,
-      you must start separate nodes before running `mix test`:
-
-      #{for n <- nodes, do: "MIX_ENV=test iex --name #{n} -S mix\n"}
-
-      If you would like to skip distributed tests, please run `mix test --exclude clustered`
-      """
-      System.halt()
-    end
+    Phoenix.PubSub.Cluster.spawn()
+    ExUnit.start()
 end


### PR DESCRIPTION
- [x] Remove the necessity to manually start slave nodes during clustered tests.

Did this mainly as an exercise for myself... So no pressure if you don't want to accept this PR.  But I saw you mentioned something in irc about this earlier, and thought I'd share what this could look like. :)

![image](https://cloud.githubusercontent.com/assets/2391584/12534129/096f2b12-c200-11e5-95ac-5da0cde72dc8.png)
