### PR TITLE
Fix monitor leak

### DIFF
--- a/lib/phoenix_pubsub/pubsub.ex
+++ b/lib/phoenix_pubsub/pubsub.ex
@@ -142,11 +142,12 @@ defmodule Phoenix.PubSub do
     when is_atom(server) and is_pid(pid) and is_binary(topic) do
     subscribe(server, pid, topic, [])
   end
+  @spec subscribe(atom, binary, Keyword.t) :: :ok | {:error, term}
   def subscribe(server, topic, opts)
     when is_atom(server) and is_binary(topic) and is_list(opts) do
     call(server, :subscribe, [self(), topic, opts])
   end
-  @spec subscribe(atom, binary, Keyword.t) :: :ok | {:error, term}
+  @spec subscribe(atom, binary) :: :ok | {:error, term}
   def subscribe(server, topic) when is_atom(server) and is_binary(topic) do
     subscribe(server, topic, [])
   end

--- a/lib/phoenix_pubsub/pubsub.ex
+++ b/lib/phoenix_pubsub/pubsub.ex
@@ -110,10 +110,9 @@ defmodule Phoenix.PubSub do
   end
 
   @doc """
-  Subscribes the pid to the PubSub adapter's topic.
+  Subscribes the caller to the PubSub adapter's topic.
 
     * `server` - The Pid registered name of the server
-    * `pid` - The subscriber pid to receive pubsub messages
     * `topic` - The topic to subscribe to, ie: `"users:123"`
     * `opts` - The optional list of options. See below.
 
@@ -135,19 +134,43 @@ defmodule Phoenix.PubSub do
       a `Phoenix.Socket.Broadcast` structs and returns a fastlaned format
       for the handler. For example:
 
-          PubSub.subscribe(MyApp.PubSub, self(), "topic1",
+          PubSub.subscribe(MyApp.PubSub, "topic1",
             fastlane: {fast_pid, Phoenix.Transports.WebSocketSerializer, ["event1"]})
   """
   @spec subscribe(atom, pid, binary, Keyword.t) :: :ok | {:error, term}
-  def subscribe(server, pid, topic, opts \\ []) when is_atom(server),
-    do: call(server, :subscribe, [pid, topic, opts])
+  def subscribe(server, pid, topic)
+    when is_atom(server) and is_pid(pid) and is_binary(topic) do
+    subscribe(server, pid, topic, [])
+  end
+  def subscribe(server, topic, opts)
+    when is_atom(server) and is_binary(topic) and is_list(opts) do
+    call(server, :subscribe, [self(), topic, opts])
+  end
+  @spec subscribe(atom, binary, Keyword.t) :: :ok | {:error, term}
+  def subscribe(server, topic) when is_atom(server) and is_binary(topic) do
+    subscribe(server, topic, [])
+  end
+  @spec subscribe(atom, pid, binary, Keyword.t) :: :ok | {:error, term}
+  def subscribe(server, pid, topic, opts) do
+    IO.write :stderr, "[warning] Passing a Pid to Phoenix.PubSub.subscribe is deprecated. " <>
+                      "Only the calling process may subscribe to topics"
+    call(server, :subscribe, [pid, topic, opts])
+  end
 
   @doc """
-  Unsubscribes the pid from the PubSub adapter's topic.
+  Unsubscribes the caller from the PubSub adapter's topic.
   """
   @spec unsubscribe(atom, pid, binary) :: :ok | {:error, term}
-  def unsubscribe(server, pid, topic) when is_atom(server),
-    do: call(server, :unsubscribe, [pid, topic])
+  def unsubscribe(server, pid, topic) when is_atom(server) do
+    IO.write :stderr, "[warning] Passing a Pid to Phoenix.PubSub.unsubscribe is deprecated. " <>
+                      "Only the calling process may unsubscribe from topics"
+    call(server, :unsubscribe, [pid, topic])
+  end
+
+  @spec unsubscribe(atom, binary) :: :ok | {:error, term}
+  def unsubscribe(server, topic) when is_atom(server) do
+    call(server, :unsubscribe, [self(), topic])
+  end
 
   @doc """
   Broadcasts message on given topic.

--- a/lib/phoenix_pubsub/tracker.ex
+++ b/lib/phoenix_pubsub/tracker.ex
@@ -229,7 +229,7 @@ defmodule Phoenix.Tracker do
                 presences: State.new(VNode.ref(vnode)),
                 broadcast_period: broadcast_period,
                 max_silent_periods: max_silent_periods,
-                silent_periods: 0,
+                silent_periods: max_silent_periods,
                 nodedown_period: nodedown_period,
                 permdown_period: permdown_period,
                 clock_sample_periods: clock_sample_periods,

--- a/lib/phoenix_pubsub/tracker.ex
+++ b/lib/phoenix_pubsub/tracker.ex
@@ -214,7 +214,7 @@ defmodule Phoenix.Tracker do
 
     case tracker.init(tracker_opts) do
       {:ok, tracker_state} ->
-        Phoenix.PubSub.subscribe(pubsub_server, self(), namespaced_topic, link: true)
+        Phoenix.PubSub.subscribe(pubsub_server, namespaced_topic, link: true)
         send_stuttered_heartbeat(self(), broadcast_period)
 
         {:ok, %{server_name: server_name,

--- a/test/phoenix_pubsub/local_test.exs
+++ b/test/phoenix_pubsub/local_test.exs
@@ -68,7 +68,7 @@ defmodule Phoenix.PubSub.LocalTest do
     end
 
     @tag pool_size: size
-    test "pool #{size}: unsubscribe/2 when topic does not exists", config do
+    test "pool #{size}: unsubscribe/2 when topic does not exist", config do
       assert :ok = Local.unsubscribe(config.pubsub, config.pool_size, self, "notexists")
       assert Enum.count(subscribers(config, "notexists")) == 0
     end
@@ -87,7 +87,7 @@ defmodule Phoenix.PubSub.LocalTest do
       Local.subscribe(config.pubsub, config.pool_size, pid, "unknown")
       Local.unsubscribe(config.pubsub, config.pool_size, pid, "unknown")
 
-      assert Local.subscription(config.pubsub, config.pool_size, pid) == []
+      assert Local.subscription(config.pubsub, config.pool_size, pid) == {nil, []}
       assert subscribers(config, "topic5") == [self]
       assert subscribers(config, "topic6") == []
 
@@ -100,15 +100,17 @@ defmodule Phoenix.PubSub.LocalTest do
       assert :ok = Local.subscribe(config.pubsub, config.pool_size, self, "topic7")
       assert :ok = Local.subscribe(config.pubsub, config.pool_size, self, "topic8")
 
-      topics = Local.subscription(config.pubsub, config.pool_size, self)
+      {ref, topics} = Local.subscription(config.pubsub, config.pool_size, self)
+      assert is_reference(ref)
       assert Enum.sort(topics) == ["topic7", "topic8"]
 
       assert :ok = Local.unsubscribe(config.pubsub, config.pool_size, self, "topic7")
-      topics = Local.subscription(config.pubsub, config.pool_size, self)
+      {ref, topics} = Local.subscription(config.pubsub, config.pool_size, self)
+      assert is_reference(ref)
       assert Enum.sort(topics) == ["topic8"]
 
       :ok = Local.unsubscribe(config.pubsub, config.pool_size, self, "topic8")
-      assert Local.subscription(config.pubsub, config.pool_size, self) == []
+      assert Local.subscription(config.pubsub, config.pool_size, self) == {nil, []}
     end
   end
 end

--- a/test/phoenix_pubsub/tracker_test.exs
+++ b/test/phoenix_pubsub/tracker_test.exs
@@ -10,11 +10,11 @@ defmodule Phoenix.TrackerTest do
   setup config do
     tracker = config.test
     {:ok, _pid} = start_tracker(name: tracker)
-    {:ok, topic: config.test, tracker: tracker}
+    {:ok, topic: to_string(config.test), tracker: tracker}
   end
 
   test "heartbeats", %{tracker: tracker} do
-    subscribe_to_tracker(self(), tracker)
+    subscribe_to_tracker(tracker)
     assert_heartbeat from: @master
     flush()
     assert_heartbeat from: @master
@@ -26,7 +26,7 @@ defmodule Phoenix.TrackerTest do
     %{tracker: tracker, topic: topic} do
 
     assert Tracker.list(tracker, topic) == []
-    subscribe_to_tracker(self(), tracker)
+    subscribe_to_tracker(tracker)
     drop_gossips(Process.whereis(tracker), tracker)
     spy_on_tracker(@slave1, self(), tracker)
     start_tracker(@slave1, name: tracker)
@@ -46,8 +46,8 @@ defmodule Phoenix.TrackerTest do
   test "requests for transfer collapses clocks",
     %{tracker: tracker, topic: topic} do
 
-    subscribe_to_tracker(self(), tracker)
-    subscribe(self(), topic)
+    subscribe_to_tracker(tracker)
+    subscribe(topic)
     for slave <- [@slave1, @slave2] do
       spy_on_tracker(slave, self(), tracker)
       start_tracker(slave, name: tracker)
@@ -90,8 +90,8 @@ defmodule Phoenix.TrackerTest do
   test "tempdowns with nodeups of new vsn, and permdowns",
     %{tracker: tracker, topic: topic} do
 
-    subscribe_to_tracker(self(), tracker)
-    subscribe(self(), topic)
+    subscribe_to_tracker(tracker)
+    subscribe(topic)
 
     {slave1_node, {:ok, slave1_tracker}} = start_tracker(@slave1, name: tracker)
     {_slave2_node, {:ok, _slave2_tracker}} = start_tracker(@slave2, name: tracker)
@@ -151,7 +151,7 @@ defmodule Phoenix.TrackerTest do
     remote_pres = spawn_pid()
 
     # local joins
-    subscribe(self(), topic)
+    subscribe(topic)
     assert Tracker.list(tracker, topic) == []
     {:ok, _ref} = Tracker.track(tracker, self(), topic, "me", %{name: "me"})
     assert_join ^topic, "me", %{name: "me"}
@@ -191,7 +191,7 @@ defmodule Phoenix.TrackerTest do
     %{tracker: tracker, topic: topic} do
 
     local_presence = spawn_pid()
-    subscribe(self(), topic)
+    subscribe(topic)
     {node_pid, {:ok, slave1_tracker}} = start_tracker(@slave1, name: tracker)
     assert Tracker.list(tracker, topic) == []
 
@@ -250,7 +250,7 @@ defmodule Phoenix.TrackerTest do
   test "updating presence sends join/leave and phx_ref_prev",
     %{tracker: tracker, topic: topic} do
 
-    subscribe(self(), topic)
+    subscribe(topic)
     {:ok, _ref} = Tracker.track(tracker, self(), topic, "u1", %{name: "u1"})
     assert [{"u1", %{name: "u1", phx_ref: ref}}] = Tracker.list(tracker, topic)
     {:ok, _ref} = Tracker.update(tracker, self(), topic, "u1", %{name: "u1-updated"})

--- a/test/support/node_case.ex
+++ b/test/support/node_case.ex
@@ -43,12 +43,12 @@ defmodule Phoenix.PubSub.NodeCase do
     end
   end
 
-  def subscribe(pid, topic) do
-    :ok = Phoenix.PubSub.subscribe(@pubsub, pid, topic)
+  def subscribe(topic) do
+    :ok = Phoenix.PubSub.subscribe(@pubsub, topic)
   end
 
-  def subscribe_to_tracker(pid, tracker) do
-    :ok = Phoenix.PubSub.subscribe(@pubsub, pid, namespaced_topic(tracker))
+  def subscribe_to_tracker(tracker) do
+    :ok = Phoenix.PubSub.subscribe(@pubsub, namespaced_topic(tracker))
   end
 
   defp namespaced_topic(tracker), do: "phx_presence:#{tracker}"
@@ -93,7 +93,7 @@ defmodule Phoenix.PubSub.NodeCase do
 
   def spy_on_pubsub(node_name, server \\ @pubsub, target_pid, topic) do
     call_node(node_name, fn ->
-      Phoenix.PubSub.subscribe(server, self(), topic)
+      Phoenix.PubSub.subscribe(server, topic)
       loop = fn next ->
         receive do
           msg -> send target_pid, {node_name, msg}


### PR DESCRIPTION
@josevalim I imagine you'll want to chat about this one. The subscriber is responsible for calling :subscribe/:unsubscribe only if they have a new topic to subscribe to or an existing one to unsubscribe from. For 1M subscribers on my laptop, subscription lookup time is ~ 50 microsecs, so it's not too costly and the lookup happens in the caller's context. The only work added to the local server is keeping tracking of the monitor refs and subscription counts, but it should be minimal. Thoughts?