### PR TITLE
Clean up warnings emissions during tests.

### DIFF
--- a/lib/phoenix_pubsub/pubsub.ex
+++ b/lib/phoenix_pubsub/pubsub.ex
@@ -283,7 +283,9 @@ defmodule Phoenix.PubSub do
     call(server, :node_name, [])
   end
 
-  defp call(server, kind, args) do
+  @doc false
+  # Non-private for test mocking
+  def call(server, kind, args) do
     [{^kind, module, head}] = :ets.lookup(server, kind)
     apply(module, kind, head ++ args)
   end

--- a/test/phoenix_pubsub/pg2_test.exs
+++ b/test/phoenix_pubsub/pg2_test.exs
@@ -23,7 +23,7 @@ defmodule Phoenix.PubSub.PG2Test do
     test "pool #{size}: direct_broadcast targets a specific node", config do
       spy_on_pubsub(@slave1, config.pubsub, self(), "some:topic")
 
-      PubSub.subscribe(config.pubsub, self, "some:topic")
+      PubSub.subscribe(config.pubsub, "some:topic")
       :ok = PubSub.direct_broadcast(@slave1, config.pubsub, "some:topic", :ping)
       assert_receive {@slave1, :ping}
       :ok = PubSub.direct_broadcast!(@slave1, config.pubsub, "some:topic", :ping)
@@ -40,7 +40,7 @@ defmodule Phoenix.PubSub.PG2Test do
     test "pool #{size}: direct_broadcast_from targets a specific node", config do
       spy_on_pubsub(@slave1, config.pubsub, self(), "some:topic")
 
-      PubSub.subscribe(config.pubsub, self, "some:topic")
+      PubSub.subscribe(config.pubsub, "some:topic")
       :ok = PubSub.direct_broadcast_from(@slave1, config.pubsub, self(), "some:topic", :ping)
       assert_receive {@slave1, :ping}
       :ok = PubSub.direct_broadcast_from!(@slave1, config.pubsub, self(), "some:topic", :ping)

--- a/test/shared/pubsub_test.exs
+++ b/test/shared/pubsub_test.exs
@@ -99,14 +99,14 @@ defmodule Phoenix.PubSubTest do
     end
 
     @tag pool_size: size
-    test "pool #{size}: subscribe/3 with link downs subscriber", config do
+    test "pool #{size}: subscribe/2 with link downs subscriber", config do
       pid = spawn_pid()
       non_linked_pid1 = spawn_pid()
       non_linked_pid2 = spawn_pid()
 
       assert rpc(pid, fn -> PubSub.subscribe(config.test, config.topic, link: true) end)
-      assert rpc(non_linked_pid1, fn -> PubSub.subscribe(config.test, non_linked_pid1, config.topic) end)
-      assert rpc(non_linked_pid2, fn -> PubSub.subscribe(config.test, non_linked_pid2, config.topic, link: false) end)
+      assert rpc(non_linked_pid1, fn -> PubSub.subscribe(config.test, config.topic) end)
+      assert rpc(non_linked_pid2, fn -> PubSub.subscribe(config.test, config.topic, link: false) end)
 
       each_shard(config, fn shard ->
         kill_and_wait(Process.whereis(Local.local_name(config.pubsub, shard)))

--- a/test/support/node_case.ex
+++ b/test/support/node_case.ex
@@ -58,11 +58,13 @@ defmodule Phoenix.PubSub.NodeCase do
   end
 
   def drop_gossips(pid, tracker) do
-    Phoenix.PubSub.unsubscribe(@pubsub, pid, namespaced_topic(tracker))
+    # Phoenix.PubSub.unsubscribe but able to unsub other PIDs
+    Phoenix.PubSub.call(@pubsub, :unsubscribe, [pid, namespaced_topic(tracker)])
   end
 
   def resume_gossips(pid, tracker) do
-    Phoenix.PubSub.subscribe(@pubsub, pid, namespaced_topic(tracker), link: true)
+    # Phoenix.PubSub.subscribe but able to sub other PIDs
+    Phoenix.PubSub.call(@pubsub, :subscribe, [pid, namespaced_topic(tracker), [link: true]])
   end
 
   def start_tracker(opts) do


### PR DESCRIPTION
- Stop using the PID-version of subscribe/unsubscribe where possible
- Expose undocumented `call` for the remaining case
- Add explicit test for the deprecation warnings

I tried to fix the `h` documentation for `subscribe` and `unsubscribe`
to only show the non-deprecated versions, but failed in the `subscribe`
case. I think `unsubscribe` might have worked because of the differing
arities between recommended and deprecated. Rather than have it
half-done I'll leave it to someone more familiar.

Please let me know if any of these changes are worrisome.  I intend to work on a more in-depth feature in the future, but wanted to see a "clean" test run before starting on anything extensive.