### PR TITLE
Replace occurances of "master/slave" terminology with "primary/replica"

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ## Testing
 
-Testing by default spawns slave nodes internally for distributed tests.
-To run tests that do not require slave nodes, exclude  the `clustered` tag:
+Testing by default spawns replica nodes internally for distributed tests.
+To run tests that do not require replica nodes, exclude  the `clustered` tag:
 
     $ mix test --exclude clustered

--- a/config/test.exs
+++ b/config/test.exs
@@ -2,7 +2,7 @@ use Mix.Config
 
 config :phoenix_pubsub,
   pubsub: [Phoenix.PubSub.Test.PubSub, [pool_size: 1]],
-  nodes: [:"slave1@127.0.0.1", :"slave2@127.0.0.1"]
+  nodes: [:"replica1@127.0.0.1", :"replica2@127.0.0.1"]
 
 config :logger,
   level: :info,

--- a/test/phoenix_pubsub/pg2_test.exs
+++ b/test/phoenix_pubsub/pg2_test.exs
@@ -8,49 +8,49 @@ defmodule Phoenix.PubSub.PG2Test do
   alias Phoenix.PubSub
   alias Phoenix.PubSub.PG2
 
-  @slave1 :"slave1@127.0.0.1"
-  @slave2 :"slave2@127.0.0.1"
+  @replica1 :"replica1@127.0.0.1"
+  @replica2 :"replica2@127.0.0.1"
 
   setup config do
     size = config[:pool_size] || 1
     {:ok, _} = PG2.start_link(config.test, pool_size: size)
-    {_, {:ok, _}} = start_pubsub(@slave1, PG2, config.test, [pool_size: size])
+    {_, {:ok, _}} = start_pubsub(@replica1, PG2, config.test, [pool_size: size])
     {:ok, %{pubsub: config.test, pool_size: size}}
   end
 
   for size <- [1, 8] do
     @tag pool_size: size
     test "pool #{size}: direct_broadcast targets a specific node", config do
-      spy_on_pubsub(@slave1, config.pubsub, self(), "some:topic")
+      spy_on_pubsub(@replica1, config.pubsub, self(), "some:topic")
 
       PubSub.subscribe(config.pubsub, "some:topic")
-      :ok = PubSub.direct_broadcast(@slave1, config.pubsub, "some:topic", :ping)
-      assert_receive {@slave1, :ping}
-      :ok = PubSub.direct_broadcast!(@slave1, config.pubsub, "some:topic", :ping)
-      assert_receive {@slave1, :ping}
+      :ok = PubSub.direct_broadcast(@replica1, config.pubsub, "some:topic", :ping)
+      assert_receive {@replica1, :ping}
+      :ok = PubSub.direct_broadcast!(@replica1, config.pubsub, "some:topic", :ping)
+      assert_receive {@replica1, :ping}
 
-      :ok = PubSub.direct_broadcast(@slave2, config.pubsub, "some:topic", :ping)
-      refute_receive {@slave1, :ping}
+      :ok = PubSub.direct_broadcast(@replica2, config.pubsub, "some:topic", :ping)
+      refute_receive {@replica1, :ping}
 
-      :ok = PubSub.direct_broadcast!(@slave2, config.pubsub, "some:topic", :ping)
-      refute_receive {@slave1, :ping}
+      :ok = PubSub.direct_broadcast!(@replica2, config.pubsub, "some:topic", :ping)
+      refute_receive {@replica1, :ping}
     end
 
     @tag pool_size: size
     test "pool #{size}: direct_broadcast_from targets a specific node", config do
-      spy_on_pubsub(@slave1, config.pubsub, self(), "some:topic")
+      spy_on_pubsub(@replica1, config.pubsub, self(), "some:topic")
 
       PubSub.subscribe(config.pubsub, "some:topic")
-      :ok = PubSub.direct_broadcast_from(@slave1, config.pubsub, self(), "some:topic", :ping)
-      assert_receive {@slave1, :ping}
-      :ok = PubSub.direct_broadcast_from!(@slave1, config.pubsub, self(), "some:topic", :ping)
-      assert_receive {@slave1, :ping}
+      :ok = PubSub.direct_broadcast_from(@replica1, config.pubsub, self(), "some:topic", :ping)
+      assert_receive {@replica1, :ping}
+      :ok = PubSub.direct_broadcast_from!(@replica1, config.pubsub, self(), "some:topic", :ping)
+      assert_receive {@replica1, :ping}
 
-      :ok = PubSub.direct_broadcast_from(@slave2, config.pubsub, self(), "some:topic", :ping)
-      refute_receive {@slave1, :ping}
+      :ok = PubSub.direct_broadcast_from(@replica2, config.pubsub, self(), "some:topic", :ping)
+      refute_receive {@replica1, :ping}
 
-      :ok = PubSub.direct_broadcast_from!(@slave2, config.pubsub, self(), "some:topic", :ping)
-      refute_receive {@slave1, :ping}
+      :ok = PubSub.direct_broadcast_from!(@replica2, config.pubsub, self(), "some:topic", :ping)
+      refute_receive {@replica1, :ping}
     end
   end
 end

--- a/test/phoenix_pubsub/tracker_test.exs
+++ b/test/phoenix_pubsub/tracker_test.exs
@@ -3,9 +3,9 @@ defmodule Phoenix.TrackerTest do
   alias Phoenix.Tracker
   alias Phoenix.Tracker.{Replica, State}
 
-  @master :"master@127.0.0.1"
-  @slave1 :"slave1@127.0.0.1"
-  @slave2 :"slave2@127.0.0.1"
+  @primary :"primary@127.0.0.1"
+  @replica1 :"replica1@127.0.0.1"
+  @replica2 :"replica2@127.0.0.1"
 
   setup config do
     tracker = config.test
@@ -15,11 +15,11 @@ defmodule Phoenix.TrackerTest do
 
   test "heartbeats", %{tracker: tracker} do
     subscribe_to_tracker(tracker)
-    assert_heartbeat from: @master
+    assert_heartbeat from: @primary
     flush()
-    assert_heartbeat from: @master
+    assert_heartbeat from: @primary
     flush()
-    assert_heartbeat from: @master
+    assert_heartbeat from: @primary
   end
 
   test "gossip from unseen node triggers nodeup and transfer request",
@@ -28,19 +28,19 @@ defmodule Phoenix.TrackerTest do
     assert list(tracker, topic) == []
     subscribe_to_tracker(tracker)
     drop_gossips(tracker)
-    spy_on_tracker(@slave1, self(), tracker)
-    start_tracker(@slave1, name: tracker)
-    track_presence(@slave1, tracker, spawn_pid(), topic, "slave1", %{})
+    spy_on_tracker(@replica1, self(), tracker)
+    start_tracker(@replica1, name: tracker)
+    track_presence(@replica1, tracker, spawn_pid(), topic, "replica1", %{})
     flush()
-    assert_heartbeat from: @slave1
+    assert_heartbeat from: @replica1
 
     resume_gossips(tracker)
-    # master sends transfer_req to slave1 after seeing behind
-    ref = assert_transfer_req to: @slave1, from: @master
-    # slave1 fulfills tranfer request and sends transfer_ack to master
-    assert_transfer_ack ref, from: @slave1
-    assert_heartbeat to: @slave1, from: @master
-    assert [{"slave1", _}] = list(tracker, topic)
+    # primary sends transfer_req to replica1 after seeing behind
+    ref = assert_transfer_req to: @replica1, from: @primary
+    # replica1 fulfills tranfer request and sends transfer_ack to primary
+    assert_transfer_ack ref, from: @replica1
+    assert_heartbeat to: @replica1, from: @primary
+    assert [{"replica1", _}] = list(tracker, topic)
   end
 
   test "requests for transfer collapses clocks",
@@ -48,42 +48,42 @@ defmodule Phoenix.TrackerTest do
 
     subscribe_to_tracker(tracker)
     subscribe(topic)
-    for slave <- [@slave1, @slave2] do
-      spy_on_tracker(slave, self(), tracker)
-      start_tracker(slave, name: tracker)
-      assert_heartbeat to: slave, from: @master
-      assert_heartbeat from: slave
+    for replica <- [@replica1, @replica2] do
+      spy_on_tracker(replica, self(), tracker)
+      start_tracker(replica, name: tracker)
+      assert_heartbeat to: replica, from: @primary
+      assert_heartbeat from: replica
     end
 
     flush()
     drop_gossips(tracker)
-    track_presence(@slave1, tracker, spawn_pid(), topic, "slave1", %{})
-    track_presence(@slave1, tracker, spawn_pid(), topic, "slave1.2", %{})
-    track_presence(@slave2, tracker, spawn_pid(), topic, "slave2", %{})
+    track_presence(@replica1, tracker, spawn_pid(), topic, "replica1", %{})
+    track_presence(@replica1, tracker, spawn_pid(), topic, "replica1.2", %{})
+    track_presence(@replica2, tracker, spawn_pid(), topic, "replica2", %{})
 
-    # slave1 sends delta broadcast to slave2
-    assert_receive {@slave1, {:pub, :heartbeat, {@slave2, _vsn}, %State{mode: :delta}, _clocks}}, @timeout
+    # replica1 sends delta broadcast to replica2
+    assert_receive {@replica1, {:pub, :heartbeat, {@replica2, _vsn}, %State{mode: :delta}, _clocks}}, @timeout
 
-    # slave2 sends delta broadcast to slave1
-    assert_receive {@slave2, {:pub, :heartbeat, {@slave1, _vsn}, %State{mode: :delta}, _clocks}}, @timeout
+    # replica2 sends delta broadcast to replica1
+    assert_receive {@replica2, {:pub, :heartbeat, {@replica1, _vsn}, %State{mode: :delta}, _clocks}}, @timeout
 
     flush()
     resume_gossips(tracker)
-    # master sends transfer_req to slave with most dominance
-    assert_receive {slave, {:pub, :transfer_req, ref, {@master, _vsn}, _state}}, @timeout * 2
-    # master does not send transfer_req to other slave, since in dominant slave's future
-    refute_received {_other, {:pub, :transfer_req, _ref, {@master, _vsn}, _state}}, @timeout * 2
-    # dominant slave fulfills transfer request and sends transfer_ack to master
-    assert_receive {:pub, :transfer_ack, ^ref, {^slave, _vsn}, _state}, @timeout
+    # primary sends transfer_req to replica with most dominance
+    assert_receive {replica, {:pub, :transfer_req, ref, {@primary, _vsn}, _state}}, @timeout * 2
+    # primary does not send transfer_req to other replica, since in dominant replica's future
+    refute_received {_other, {:pub, :transfer_req, _ref, {@primary, _vsn}, _state}}, @timeout * 2
+    # dominant replica fulfills transfer request and sends transfer_ack to primary
+    assert_receive {:pub, :transfer_ack, ^ref, {^replica, _vsn}, _state}, @timeout
 
     # wait for local sync
-    assert_join ^topic, "slave1", %{}
-    assert_join ^topic, "slave1.2", %{}
-    assert_join ^topic, "slave2", %{}
-    assert_heartbeat from: @slave1
-    assert_heartbeat from: @slave2
+    assert_join ^topic, "replica1", %{}
+    assert_join ^topic, "replica1.2", %{}
+    assert_join ^topic, "replica2", %{}
+    assert_heartbeat from: @replica1
+    assert_heartbeat from: @replica2
 
-    assert [{"slave1", _}, {"slave1.2", _}, {"slave2", _}] = list(tracker, topic)
+    assert [{"replica1", _}, {"replica1.2", _}, {"replica2", _}] = list(tracker, topic)
   end
 
   # TODO split into multiple testscases
@@ -93,55 +93,55 @@ defmodule Phoenix.TrackerTest do
     subscribe_to_tracker(tracker)
     subscribe(topic)
 
-    {slave1_node, {:ok, slave1_tracker}} = start_tracker(@slave1, name: tracker)
-    {_slave2_node, {:ok, _slave2_tracker}} = start_tracker(@slave2, name: tracker)
-    for slave <- [@slave1, @slave2] do
-      track_presence(slave, tracker, spawn_pid(), topic, slave, %{})
-      assert_join ^topic, ^slave, %{}
+    {replica1_node, {:ok, replica1_tracker}} = start_tracker(@replica1, name: tracker)
+    {_replica2_node, {:ok, _replica2_tracker}} = start_tracker(@replica2, name: tracker)
+    for replica <- [@replica1, @replica2] do
+      track_presence(replica, tracker, spawn_pid(), topic, replica, %{})
+      assert_join ^topic, ^replica, %{}
     end
-    assert_map %{@slave1 => %Replica{status: :up, vsn: vsn_before},
-                 @slave2 => %Replica{status: :up}}, replicas(tracker), 2
+    assert_map %{@replica1 => %Replica{status: :up, vsn: vsn_before},
+                 @replica2 => %Replica{status: :up}}, replicas(tracker), 2
 
     # tempdown netsplit
     flush()
-    :ok = :sys.suspend(slave1_tracker)
-    assert_leave ^topic, @slave1, %{}
-    assert_map %{@slave1 => %Replica{status: :down, vsn: ^vsn_before},
-                 @slave2 => %Replica{status: :up}}, replicas(tracker), 2
+    :ok = :sys.suspend(replica1_tracker)
+    assert_leave ^topic, @replica1, %{}
+    assert_map %{@replica1 => %Replica{status: :down, vsn: ^vsn_before},
+                 @replica2 => %Replica{status: :up}}, replicas(tracker), 2
     flush()
-    :ok = :sys.resume(slave1_tracker)
-    assert_join ^topic, @slave1, %{}
-    assert_heartbeat from: @slave1
-    assert_map %{@slave1 => %Replica{status: :up, vsn: ^vsn_before},
-                 @slave2 => %Replica{status: :up}}, replicas(tracker), 2
+    :ok = :sys.resume(replica1_tracker)
+    assert_join ^topic, @replica1, %{}
+    assert_heartbeat from: @replica1
+    assert_map %{@replica1 => %Replica{status: :up, vsn: ^vsn_before},
+                 @replica2 => %Replica{status: :up}}, replicas(tracker), 2
 
     # tempdown crash
-    Process.unlink(slave1_node)
-    Process.exit(slave1_tracker, :kill)
-    assert_leave ^topic, @slave1, %{}
-    assert_map %{@slave1 => %Replica{status: :down},
-                 @slave2 => %Replica{status: :up}}, replicas(tracker), 2
+    Process.unlink(replica1_node)
+    Process.exit(replica1_tracker, :kill)
+    assert_leave ^topic, @replica1, %{}
+    assert_map %{@replica1 => %Replica{status: :down},
+                 @replica2 => %Replica{status: :up}}, replicas(tracker), 2
 
     # tempdown => nodeup with new vsn
-    {slave1_node, {:ok, slave1_tracker}} = start_tracker(@slave1, name: tracker)
-    track_presence(@slave1, tracker, spawn_pid(), topic, "slave1-back", %{})
-    assert_join ^topic, "slave1-back", %{}
-    assert [{@slave2, _}, {"slave1-back", _}] = list(tracker, topic)
-    assert_map %{@slave1 => %Replica{status: :up, vsn: new_vsn},
-                 @slave2 => %Replica{status: :up}}, replicas(tracker), 2
+    {replica1_node, {:ok, replica1_tracker}} = start_tracker(@replica1, name: tracker)
+    track_presence(@replica1, tracker, spawn_pid(), topic, "replica1-back", %{})
+    assert_join ^topic, "replica1-back", %{}
+    assert [{@replica2, _}, {"replica1-back", _}] = list(tracker, topic)
+    assert_map %{@replica1 => %Replica{status: :up, vsn: new_vsn},
+                 @replica2 => %Replica{status: :up}}, replicas(tracker), 2
     assert vsn_before != new_vsn
 
     # tempdown again
-    Process.unlink(slave1_node)
-    Process.exit(slave1_tracker, :kill)
-    assert_leave ^topic, "slave1-back", %{}
-    assert_map %{@slave1 => %Replica{status: :down},
-                 @slave2 => %Replica{status: :up}}, replicas(tracker), 2
+    Process.unlink(replica1_node)
+    Process.exit(replica1_tracker, :kill)
+    assert_leave ^topic, "replica1-back", %{}
+    assert_map %{@replica1 => %Replica{status: :down},
+                 @replica2 => %Replica{status: :up}}, replicas(tracker), 2
 
     # tempdown => permdown
     flush()
-    for _ <- 0..trunc(@permdown / @heartbeat), do: assert_heartbeat(from: @master)
-    assert_map %{@slave2 => %Replica{status: :up}}, replicas(tracker), 1
+    for _ <- 0..trunc(@permdown / @heartbeat), do: assert_heartbeat(from: @primary)
+    assert_map %{@replica2 => %Replica{status: :up}}, replicas(tracker), 1
   end
 
   test "replicates and locally broadcasts presence_join/leave",
@@ -165,25 +165,25 @@ defmodule Phoenix.TrackerTest do
 
     # remote joins
     assert replicas(tracker) == %{}
-    start_tracker(@slave1, name: tracker)
-    track_presence(@slave1, tracker, remote_pres, topic, "slave1", %{name: "s1"})
-    assert_join ^topic, "slave1", %{name: "s1"}
-    assert_map %{@slave1 => %Replica{status: :up}}, replicas(tracker), 1
+    start_tracker(@replica1, name: tracker)
+    track_presence(@replica1, tracker, remote_pres, topic, "replica1", %{name: "s1"})
+    assert_join ^topic, "replica1", %{name: "s1"}
+    assert_map %{@replica1 => %Replica{status: :up}}, replicas(tracker), 1
     assert [{"me", %{name: "me", phx_ref: _}},
             {"me2",%{name: "me2", phx_ref: _}},
-            {"slave1", %{name: "s1", phx_ref: _}}] =
+            {"replica1", %{name: "s1", phx_ref: _}}] =
            list(tracker, topic)
 
     # local leaves
     Process.exit(local_presence, :kill)
     assert_leave ^topic, "me2", %{name: "me2"}
     assert [{"me", %{name: "me", phx_ref: _}},
-            {"slave1", %{name: "s1", phx_ref: _}}] =
+            {"replica1", %{name: "s1", phx_ref: _}}] =
            list(tracker, topic)
 
     # remote leaves
     Process.exit(remote_pres, :kill)
-    assert_leave ^topic, "slave1", %{name: "s1"}
+    assert_leave ^topic, "replica1", %{name: "s1"}
     assert [{"me", %{name: "me", phx_ref: _}}] = list(tracker, topic)
   end
 
@@ -192,22 +192,22 @@ defmodule Phoenix.TrackerTest do
 
     local_presence = spawn_pid()
     subscribe(topic)
-    {node_pid, {:ok, slave1_tracker}} = start_tracker(@slave1, name: tracker)
+    {node_pid, {:ok, replica1_tracker}} = start_tracker(@replica1, name: tracker)
     assert list(tracker, topic) == []
 
     {:ok, _ref} = Tracker.track(tracker, local_presence , topic, "local1", %{name: "l1"})
     assert_join ^topic, "local1", %{}
 
-    track_presence(@slave1, tracker, spawn_pid(), topic, "slave1", %{name: "s1"})
-    assert_join ^topic, "slave1", %{name: "s1"}
-    assert %{@slave1 => %Replica{status: :up}} = replicas(tracker)
-    assert [{"local1", _}, {"slave1", _}] = list(tracker, topic)
+    track_presence(@replica1, tracker, spawn_pid(), topic, "replica1", %{name: "s1"})
+    assert_join ^topic, "replica1", %{name: "s1"}
+    assert %{@replica1 => %Replica{status: :up}} = replicas(tracker)
+    assert [{"local1", _}, {"replica1", _}] = list(tracker, topic)
 
     # nodedown
     Process.unlink(node_pid)
-    Process.exit(slave1_tracker, :kill)
-    assert_leave ^topic, "slave1", %{name: "s1"}
-    assert %{@slave1 => %Replica{status: :down}} = replicas(tracker)
+    Process.exit(replica1_tracker, :kill)
+    assert_leave ^topic, "replica1", %{name: "s1"}
+    assert %{@replica1 => %Replica{status: :down}} = replicas(tracker)
     assert [{"local1", _}] = list(tracker, topic)
   end
 
@@ -265,15 +265,15 @@ defmodule Phoenix.TrackerTest do
 
   test "graceful exits with permdown", %{tracker: tracker, topic: topic} do
     subscribe(topic)
-    {_node_pid, {:ok, _slave1_tracker}} = start_tracker(@slave1, name: tracker)
-    track_presence(@slave1, tracker, spawn_pid(), topic, "slave1", %{name: "s1"})
-    assert_join ^topic, "slave1", %{name: "s1"}
-    assert %{@slave1 => %Replica{status: :up}} = replicas(tracker)
-    assert [{"slave1", _}] = list(tracker, topic)
+    {_node_pid, {:ok, _replica1_tracker}} = start_tracker(@replica1, name: tracker)
+    track_presence(@replica1, tracker, spawn_pid(), topic, "replica1", %{name: "s1"})
+    assert_join ^topic, "replica1", %{name: "s1"}
+    assert %{@replica1 => %Replica{status: :up}} = replicas(tracker)
+    assert [{"replica1", _}] = list(tracker, topic)
 
     # graceful permdown
-    {_, :ok} = graceful_permdown(@slave1, tracker)
-    assert_leave ^topic, "slave1", %{name: "s1"}
+    {_, :ok} = graceful_permdown(@replica1, tracker)
+    assert_leave ^topic, "replica1", %{name: "s1"}
     assert [] = list(tracker, topic)
     assert replicas(tracker) == %{}
   end


### PR DESCRIPTION
The code, docs, and some tests contain references to a master/slave replication configuration.
While this terminology has been used for a long time, those terms may carry racially charged meanings to users.
This patch replaces all occurrences of master and slave with 'primary' and 'replica', following the Django Project's lead.

@see: https://github.com/django/django/pull/2692 and https://github.com/django/django/pull/2694

N.B. - there are two private functions in `tests/` where the slave terminology is still used, because they are calling erlang directly. This should be the exception and not the rule.