### PR TITLE
Optimize lookups with ets pids table

### DIFF
--- a/lib/phoenix_pubsub/tracker/delta_generation.ex
+++ b/lib/phoenix_pubsub/tracker/delta_generation.ex
@@ -33,7 +33,7 @@ defmodule Phoenix.Tracker.DeltaGeneration do
   defp do_push([gen | generations], delta, [gen_max | opts], {prev, acc}) do
     case State.merge_deltas(gen, delta) do
       {:ok, merged} ->
-        if State.size(merged) <= gen_max do
+        if State.delta_size(merged) <= gen_max do
           do_push(generations, delta, opts, {merged, [merged | acc]})
         else
           do_push(generations, delta, opts, {merged, [prev | acc]})

--- a/lib/phoenix_pubsub/tracker/replica.ex
+++ b/lib/phoenix_pubsub/tracker/replica.ex
@@ -26,7 +26,7 @@ defmodule Phoenix.Tracker.Replica do
   """
   @spec new(name) :: Replica.t
   def new(name) do
-    %Replica{name: name, vsn: {now_ms(), System.unique_integer()}}
+    %Replica{name: name, vsn: unique_vsn()}
   end
 
   @spec ref(Replica.t) :: replica_ref
@@ -77,8 +77,9 @@ defmodule Phoenix.Tracker.Replica do
     %Replica{replica | last_heartbeat_at: now_ms()}
   end
 
-  defp now_ms, do: :os.timestamp() |> time_to_ms()
-  defp time_to_ms({mega, sec, micro}) do
-    trunc(((mega * 1000000 + sec) * 1000) + (micro / 1000))
+  defp now_ms, do: System.system_time(:milli_seconds)
+
+  defp unique_vsn do
+    System.system_time(:micro_seconds) + System.unique_integer([:positive])
   end
 end

--- a/test/phoenix_pubsub/tracker/delta_generation_test.exs
+++ b/test/phoenix_pubsub/tracker/delta_generation_test.exs
@@ -17,7 +17,7 @@ defmodule Phoenix.Tracker.DeltaGenerationTest do
     |> Enum.sort()
   end
 
-  test "empty generations" do
+  test "generations" do
     s1 = new(:s1)
     s2 = new(:s2)
     s1 = State.join(s1, new_pid(), "lobby", "user1", %{})


### PR DESCRIPTION
Add pids table for reverse lookup against
values table for efficient matching of
get_by_pid.

Optimize ets select for get_by_topic
by or'ing downed node comparisons.