### PR TITLE
Add ability to intercept pubsub messages

### DIFF
--- a/lib/phoenix_pubsub/interceptor.ex
+++ b/lib/phoenix_pubsub/interceptor.ex
@@ -1,0 +1,47 @@
+defmodule Phoenix.PubSub.Interceptor do
+  @moduledoc ~S"""
+  A behaviour for intercepting PubSub messages before they are relayed locally.
+
+  Allows broadcasted messages to be intercepted before being forwarded to
+  node-local subscribers. Useful for customizing and filtering messages
+  before subscribers receive them.
+
+  ## Examples
+
+      defmodule MyApp.PubSub.Interceptor do
+        use Phoenix.PubSub.Interceptor
+
+        def handle_broadcast("topic1", msg, _server) do
+          :ignore # do not relay message to subscribers
+        end
+
+        def handle_broadcast("topic2", :ping, _server) do
+          {:ok, :pang} # custmize message before relaying to subscribers
+        end
+
+        def handle_broadcast("topic3", :ping, server) do
+          # broadcast additional message to local subscribers
+          Phoenix.PubSub.local_broadcast(server, "another:topic", :intercepted)
+          {:ok, :ping}
+        end
+      end
+  """
+  @type topic :: String.t
+  @type message :: term
+  @type pubsub_server :: atom
+
+  @callback handle_broadcast(topic, message, pubsub_server) :: {:ok, message} | :ignore
+
+  defmacro __using__(_opts) do
+    quote do
+      import unquote(__MODULE__)
+      @before_compile unquote(__MODULE__)
+    end
+  end
+
+  defmacro __before_compile__(_env) do
+    quote do
+      def handle_broadcast(_topic, message, _pubsub_server), do: {:ok, message}
+    end
+  end
+end

--- a/lib/phoenix_pubsub/pg2.ex
+++ b/lib/phoenix_pubsub/pg2.ex
@@ -22,6 +22,8 @@ defmodule Phoenix.PubSub.PG2 do
       clients, a pool size equal to the number of schedulers (cores) is a well
       rounded size.
 
+    * `:interceptor` - The optional callback module implementing the
+      `Phoenix.PubSub.Interceptor` behaviour.
   """
 
   def start_link(name, opts) do
@@ -33,8 +35,11 @@ defmodule Phoenix.PubSub.PG2 do
   def init([server, opts]) do
     pool_size = Keyword.fetch!(opts, :pool_size)
     node_name = opts[:node_name]
-    dispatch_rules = [{:broadcast, Phoenix.PubSub.PG2Server, [opts[:fastlane], server, pool_size]},
-                      {:direct_broadcast, Phoenix.PubSub.PG2Server, [opts[:fastlane], server, pool_size]},
+    fastlane = opts[:fastlane]
+    interceptor = opts[:interceptor]
+
+    dispatch_rules = [{:broadcast, Phoenix.PubSub.PG2Server, [interceptor, fastlane, server, pool_size]},
+                      {:direct_broadcast, Phoenix.PubSub.PG2Server, [interceptor, fastlane, server, pool_size]},
                       {:node_name, __MODULE__, [node_name]}]
 
     children = [

--- a/lib/phoenix_pubsub/pg2_server.ex
+++ b/lib/phoenix_pubsub/pg2_server.ex
@@ -8,32 +8,32 @@ defmodule Phoenix.PubSub.PG2Server do
     GenServer.start_link __MODULE__, server_name, name: server_name
   end
 
-  def direct_broadcast(fastlane, server_name, pool_size, node_name, from_pid, topic, msg) do
+  def direct_broadcast(interceptor, fastlane, server_name, pool_size, node_name, from_pid, topic, msg) do
     server_name
     |> get_members(node_name)
-    |> do_broadcast(fastlane, server_name, pool_size, from_pid, topic, msg)
+    |> do_broadcast(interceptor, fastlane, server_name, pool_size, from_pid, topic, msg)
   end
 
-  def broadcast(fastlane, server_name, pool_size, from_pid, topic, msg) do
+  def broadcast(interceptor, fastlane, server_name, pool_size, from_pid, topic, msg) do
     server_name
     |> get_members()
-    |> do_broadcast(fastlane, server_name, pool_size, from_pid, topic, msg)
+    |> do_broadcast(interceptor, fastlane, server_name, pool_size, from_pid, topic, msg)
   end
 
-  defp do_broadcast({:error, {:no_such_group, _}}, _fastlane, _server, _pool, _from, _topic, _msg) do
+  defp do_broadcast({:error, {:no_such_group, _}}, _interceptor, _fastlane, _server, _pool, _from, _topic, _msg) do
     {:error, :no_such_group}
   end
-  defp do_broadcast(pids, fastlane, server_name, pool_size, from_pid, topic, msg)
+  defp do_broadcast(pids, interceptor, fastlane, server_name, pool_size, from_pid, topic, msg)
     when is_list(pids) do
     local_node = Phoenix.PubSub.node_name(server_name)
 
     Enum.each(pids, fn
       pid when is_pid(pid) and node(pid) == node() ->
-        Local.broadcast(fastlane, server_name, pool_size, from_pid, topic, msg)
+        Local.broadcast(interceptor, fastlane, server_name, pool_size, from_pid, topic, msg)
       {^server_name, node_name} when node_name == local_node ->
-        Local.broadcast(fastlane, server_name, pool_size, from_pid, topic, msg)
+        Local.broadcast(interceptor, fastlane, server_name, pool_size, from_pid, topic, msg)
       pid_or_tuple ->
-        send(pid_or_tuple, {:forward_to_local, fastlane, from_pid, pool_size, topic, msg})
+        send(pid_or_tuple, {:forward_to_local, interceptor, fastlane, from_pid, pool_size, topic, msg})
     end)
     :ok
   end
@@ -46,10 +46,10 @@ defmodule Phoenix.PubSub.PG2Server do
     {:ok, server_name}
   end
 
-  def handle_info({:forward_to_local, fastlane, from_pid, pool_size, topic, msg}, name) do
+  def handle_info({:forward_to_local, interceptor, fastlane, from_pid, pool_size, topic, msg}, name) do
     # The whole broadcast will happen inside the current process
     # but only for messages coming from the distributed system.
-    Local.broadcast(fastlane, name, pool_size, from_pid, topic, msg)
+    Local.broadcast(interceptor, fastlane, name, pool_size, from_pid, topic, msg)
     {:noreply, name}
   end
 

--- a/lib/phoenix_pubsub/pubsub.ex
+++ b/lib/phoenix_pubsub/pubsub.ex
@@ -201,6 +201,36 @@ defmodule Phoenix.PubSub do
     do: call(server, :direct_broadcast, [node_name, :none, topic, message])
 
   @doc """
+  Broadcasts message on given topic, to the local node.
+
+    * `server` - The Pid or registered server name and optional node to
+      scope the broadcast, for example: `MyApp.PubSub`, `{MyApp.PubSub, :a@node}`
+    * `topic` - The topic to broadcast to, ie: `"users:123"`
+    * `message` - The payload of the broadcast
+
+  """
+  @spec local_broadcast(atom, binary, term) :: :ok | {:error, term}
+  def local_broadcast(server, topic, message) when is_atom(server) do
+    server
+    |> node_name()
+    |> direct_broadcast(server, topic, message)
+  end
+
+
+  @doc """
+  Broadcasts message on given topic, to the local node.
+
+  Raises `Phoenix.PubSub.BroadcastError` if broadcast fails.
+  See `Phoenix.PubSub.broadcast/3` for usage details.
+  """
+  @spec local_broadcast!(atom, binary, term) :: :ok | no_return
+  def local_broadcast!(server, topic, message) do
+    server
+    |> node_name()
+    |> direct_broadcast!(server, topic, message)
+  end
+
+  @doc """
   Broadcasts message on given topic.
 
   Raises `Phoenix.PubSub.BroadcastError` if broadcast fails.

--- a/test/shared/pubsub_test.exs
+++ b/test/shared/pubsub_test.exs
@@ -127,6 +127,15 @@ defmodule Phoenix.PubSubTest do
     end
 
     @tag pool_size: size
+    test "pool #{size}: local_broadcast/3 and local_broadcast!/3 publishes message to local subscribers", config do
+      PubSub.subscribe(config.test, "topic9")
+      :ok = PubSub.local_broadcast(config.test, "topic9", :ping)
+      assert_receive :ping
+      :ok = PubSub.local_broadcast!(config.test, "topic9", :ping)
+      assert_receive :ping
+    end
+
+    @tag pool_size: size
     test "pool #{size}: broadcast/3 does not publish message to other topic subscribers", config do
       PubSub.subscribe(config.test, "topic9")
 


### PR DESCRIPTION
@josevalim this is an experiment from ideas we discussed earlier today. I realized we could support efficient message intercepting without a central process by making a simple callback module. See the `Phoenix.PubSub.Interceptor` moduledoc for example usage. Thoughts?