### PR TITLE
Set default pool size to number of schedulers

### DIFF
--- a/lib/phoenix_pubsub/pg2.ex
+++ b/lib/phoenix_pubsub/pg2.ex
@@ -17,10 +17,10 @@ defmodule Phoenix.PubSub.PG2 do
       When only a server name is provided, the node name defaults to `node()`.
 
     * `:pool_size` - Both the size of the local pubsub server pool and subscriber
-      shard size. Defaults `1`. A single pool is often enough for most use-cases,
-      but for high subscriber counts on a single topic or greater than 1M
-      clients, a pool size equal to the number of schedulers (cores) is a well
-      rounded size.
+      shard size. Defaults the number of schedulers (cores). A single pool is
+      often enough for most use-cases, but for high subscriber counts on a single
+      topic or greater than 1M clients, a pool size equal to the number of
+      schedulers (cores) is a well rounded size.
 
   """
 
@@ -31,7 +31,8 @@ defmodule Phoenix.PubSub.PG2 do
 
   @doc false
   def init([server, opts]) do
-    pool_size = Keyword.fetch!(opts, :pool_size)
+    scheduler_count = :erlang.system_info(:schedulers)
+    pool_size = Keyword.get(opts, :pool_size, scheduler_count)
     node_name = opts[:node_name]
     dispatch_rules = [{:broadcast, Phoenix.PubSub.PG2Server, [opts[:fastlane], server, pool_size]},
                       {:direct_broadcast, Phoenix.PubSub.PG2Server, [opts[:fastlane], server, pool_size]},

--- a/test/phoenix_pubsub/pg2_test.exs
+++ b/test/phoenix_pubsub/pg2_test.exs
@@ -13,7 +13,11 @@ defmodule Phoenix.PubSub.PG2Test do
 
   setup config do
     size = config[:pool_size] || 1
-    {:ok, _} = PG2.start_link(config.test, pool_size: size)
+    if config[:pool_size] do
+      {:ok, _} = PG2.start_link(config.test, pool_size: size)
+    else
+      {:ok, _} = PG2.start_link(config.test, [])
+    end
     {_, {:ok, _}} = start_pubsub(@node1, PG2, config.test, [pool_size: size])
     {:ok, %{pubsub: config.test, pool_size: size}}
   end
@@ -52,5 +56,10 @@ defmodule Phoenix.PubSub.PG2Test do
       :ok = PubSub.direct_broadcast_from!(@node2, config.pubsub, self(), "some:topic", :ping)
       refute_receive {@node1, :ping}
     end
+  end
+
+  test "pool size defaults to number of schedulers", config do
+    last_shard = :erlang.system_info(:schedulers) -1
+    assert Phoenix.PubSub.Local.subscribers(config.pubsub, "some:topic", last_shard) == []
   end
 end


### PR DESCRIPTION
Maybe there is a better way to do the test than checking that the last shard subscriber count?