### PR TITLE
Fix xref warning for `Mix.Tasks.Phoenix.PubSub.Bench`

### DIFF
--- a/tasks/phoenix.pub_sub.bench.exs
+++ b/tasks/phoenix.pub_sub.bench.exs
@@ -54,7 +54,7 @@ defmodule Mix.Tasks.Phoenix.PubSub.Bench do
     end
 
     time "get_by_pid/4 for #{size * 2} element set", fn ->
-      State.get_by_pid(s1, pid, topic, key) || raise(:none)
+      State.get_by_pid(s1, pid, topic, key) || raise("none")
     end
 
     s1 = State.compact(s1)


### PR DESCRIPTION
On latest Elixir master with xref:

```
==> phoenix_pubsub
Compiling 13 files (.ex)
warning: function :none.exception/1 is undefined (module :none is not available)
  lib/mix/tasks/phoenix.pub_sub.bench.ex:57

Generated phoenix_pubsub app
```