### PR TITLE
Allow partially updating `meta`

### DIFF
--- a/lib/phoenix/tracker.ex
+++ b/lib/phoenix/tracker.ex
@@ -177,7 +177,7 @@ defmodule Phoenix.Tracker do
       iex> Phoenix.Tracker.update(MyTracker, self, "lobby", u.id, fn meta -> Map.put(meta, :away, true) end)
       {:ok, "1WpAofWYIAA="}
   """
-  @spec update(atom, pid, topic, term, Map.t) :: {:ok, ref :: binary} | {:error, reason :: term}
+  @spec update(atom, pid, topic, term, Map.t | (Map.t -> Map.t)) :: {:ok, ref :: binary} | {:error, reason :: term}
   def update(server_name, pid, topic, key, meta) when is_pid(pid) and (is_map(meta) or is_function(meta)) do
     GenServer.call(server_name, {:update, pid, topic, key, meta})
   end

--- a/lib/phoenix/tracker.ex
+++ b/lib/phoenix/tracker.ex
@@ -361,12 +361,12 @@ defmodule Phoenix.Tracker do
     {:reply, :ok, drop_presence(state, pid)}
   end
 
-  def handle_call({:update, pid, topic, key, meta_updater}, from, state) when is_function(meta_updater) do
-    handle_update({pid, topic, key, meta_updater}, from, state)
+  def handle_call({:update, pid, topic, key, meta_updater}, _from, state) when is_function(meta_updater) do
+    handle_update({pid, topic, key, meta_updater}, state)
   end
 
-  def handle_call({:update, pid, topic, key, new_meta}, from, state) do
-    handle_update({pid, topic, key, fn _ -> new_meta end}, from, state)
+  def handle_call({:update, pid, topic, key, new_meta}, _from, state) do
+    handle_update({pid, topic, key, fn _ -> new_meta end}, state)
   end
 
   def handle_call(:graceful_permdown, _from, state) do
@@ -607,7 +607,7 @@ defmodule Phoenix.Tracker do
     """
   end
 
-  defp handle_update({pid, topic, key, meta_updater}, _from, state) do
+  defp handle_update({pid, topic, key, meta_updater}, state) do
     case State.get_by_pid(state.presences, pid, topic, key) do
       nil ->
         {:reply, {:error, :nopresence}, state}

--- a/test/phoenix/tracker/integration_test.exs
+++ b/test/phoenix/tracker/integration_test.exs
@@ -258,6 +258,17 @@ defmodule Phoenix.Tracker.IntegrationTest do
     assert_join ^topic, "u1", %{name: "u1-updated", phx_ref_prev: ^ref}
   end
 
+  test "updating presence sends join/leave and phx_ref_prev with profer diffs if function for update used",
+    %{tracker: tracker, topic: topic} do
+
+    subscribe(topic)
+    {:ok, _ref} = Tracker.track(tracker, self(), topic, "u1", %{browser: "Chrome", status: "online"})
+    assert [{"u1", %{browser: "Chrome", status: "online", phx_ref: ref}}] = list(tracker, topic)
+    {:ok, _ref} = Tracker.update(tracker, self(), topic, "u1", fn meta -> Map.put(meta, :status, "away") end)
+    assert_leave ^topic, "u1", %{browser: "Chrome", status: "online", phx_ref: ^ref}
+    assert_join ^topic, "u1", %{browser: "Chrome", status: "away", phx_ref_prev: ^ref}
+  end
+
   test "updating with no prior presence", %{tracker: tracker, topic: topic} do
     assert {:error, :nopresence} = Tracker.update(tracker, self(), topic, "u1", %{})
   end


### PR DESCRIPTION
Hey! 

First of all, thank you for your great work! Phoenix and its Channel/Presence capabilities are absolutely cool and they give a lot of fun for developing web applications again!

I've opened this Pull Request as I couldn't find proper way of doing this. Please, consider following:


```elixir
Presence.track(socket, socket.assigns.user_id, %{browser: "Chrome", status: "online"})
```

which is similar to what's described in video from this great blog post: [What makes Phoenix Presence special, and a sneak peek](https://dockyard.com/blog/2016/03/25/what-makes-phoenix-presence-special-sneak-peek).

There is a way of updating _current_meta_ with [`Phoenix.Tracker.update/5`](https://github.com/phoenixframework/phoenix_pubsub/blob/master/lib/phoenix/tracker.ex#L178), but it expects _full `meta`_ to be passed.

If I wanted to continue my example, I would need to do:

```elixir
Presence.update(socket, socket.assigns.user_id, %{browser: "Chrome", status: "away"})
```

This unfortunately requires you to know whole current `meta`, update only the `key` you're interested in and set it back again. This could be solved by storing a _copy_ of current `meta` in separate process (within the opened channel), but feels redundant and complicated for a simple thing I'd like to achieve.

I've played with it a bit, and it looks like this could be easily achieved if you we're able to pass a `function` instead of whole `map`.

Please, consider this example:

```elixir
Presence.update(socket, socket.assigns.user_id, fn meta -> Map.put(meta, :status, "away"))
``` 

With this simple change it feels like the solution is much more flexible and powerful! What do you think about such an approach?

I was thinking if it could be simply handled by `update` function that accepts `function` and `map`, or maybe introducing new one - like `update_with`?

Even the code provided here works I'm not happy with it. The [guard with nested condition](https://github.com/phoenixframework/phoenix_pubsub/compare/master...pdawczak:pd-tracker-update?expand=1#diff-fc3d1e8efd95176c339eaafe5ab24ad6R181) just feels wrong (not to mention, that `@spec` requires updating and I'm not sure what would the proper signature look like); secondly, the [`handle_call`](https://github.com/phoenixframework/phoenix_pubsub/compare/master...pdawczak:pd-tracker-update?expand=1#diff-fc3d1e8efd95176c339eaafe5ab24ad6R364) is almost exact copy of the original one with slight change to execute provided function. Unfortunately, I wasn't sure how to refactor those functions (maybe there would not be much point if there was decision about creating distinct function).

I just wanted to open conversation with such a simple PR. Is this approach something you could consider valuable and possibly beneficial for others? Any comments are welcome (there is no better way of learning new tool than just diving into it).

With best regards,
Paweł Dawczak