### PR TITLE
Trivial Documentation Change

### DIFF
--- a/lib/phoenix/pubsub.ex
+++ b/lib/phoenix/pubsub.ex
@@ -47,11 +47,11 @@ defmodule Phoenix.PubSub do
   You can now use the functions in this module to subscribe
   and broadcast messages:
 
-      iex> PubSub.subscribe MyApp.PubSub, self, "user:123"
+      iex> PubSub.subscribe :my_redis_pubsub, self, "user:123"
       :ok
       iex> Process.info(self)[:messages]
       []
-      iex> PubSub.broadcast MyApp.PubSub, "user:123", {:user_update, %{id: 123, name: "Shane"}}
+      iex> PubSub.broadcast :my_redis_pubsub, "user:123", {:user_update, %{id: 123, name: "Shane"}}
       :ok
       iex> Process.info(self)[:messages]
       {:user_update, %{id: 123, name: "Shane"}}


### PR DESCRIPTION
A very small change aimed at improving the consistency of the documentation in the Direct usage section of the Phoenix.PubSub module.

The first code snippet in the section shows how to create a new PubSub instance and give it a name, but the second snippet uses a different name to demonstrate subcribing and broadcasting.  This change uses the PubSub instance's name consistently in both code samples.