### PR TITLE
Prune perm-downed replicas from delta generations to fix zombie pids

### DIFF
--- a/lib/phoenix/tracker/delta_generation.ex
+++ b/lib/phoenix/tracker/delta_generation.ex
@@ -1,7 +1,7 @@
 defmodule Phoenix.Tracker.DeltaGeneration do
   @moduledoc false
   require Logger
-  alias Phoenix.Tracker.{State, Clock}
+  alias Phoenix.Tracker.{State, Clock, Replica}
 
   @doc """
   Extracts minimal delta from generations to satisfy remote clock.
@@ -42,6 +42,16 @@ defmodule Phoenix.Tracker.DeltaGeneration do
       {:error, :not_contiguous} ->
         do_push(generations, delta, opts, {gen, [gen | acc]})
     end
+  end
+
+  @doc """
+  Prunes permanently downed replicaes from the delta generation list
+  """
+  @spec remove_down_replicas([State.delta], Replica.replica_ref) :: [State.delta]
+  def remove_down_replicas(generations, replica_ref) do
+    Enum.map(generations, fn %State{mode: :delta} = gen ->
+      State.remove_down_replicas(gen, replica_ref)
+    end)
   end
 
   defp delta_fullfilling_clock(generations, remote_clock) do

--- a/test/phoenix/tracker/delta_generation_test.exs
+++ b/test/phoenix/tracker/delta_generation_test.exs
@@ -92,4 +92,15 @@ defmodule Phoenix.Tracker.DeltaGenerationTest do
     assert [gen1, gen1, gen1] = gens = push(s1, [], old_s3.delta, [5, 10, 15])
     assert [^gen1, ^gen1, ^gen1] = push(s1, gens, s3.delta, [5, 10, 15])
   end
+
+  test "remove_down_replicas" do
+    s1 = new(:s1)
+    s2 = new(:s2)
+    s3 = new(:s3)
+    s2 = State.join(s2, new_pid(), "lobby", "user2", %{})
+    assert [gen1, gen1, gen1] = gens = push(s1, [], s2.delta, [5, 10, 15])
+    assert [pruned_gen1, pruned_gen1, pruned_gen1] = DeltaGeneration.remove_down_replicas(gens, :s2)
+    assert {s3, [], []} = State.merge(s3, pruned_gen1)
+    assert State.get_by_topic(s3, "lobby") == []
+  end
 end


### PR DESCRIPTION
Zombie pids could reappear in cases where a delta generation
was sent to catch-up a replica containing a previously perm-downed
version of that replica. Properly prune delta generations to prevent
this.

// @Gazler @gabiz This should be fixed on this PR. Please verify this branch against your setup. Thanks!