### PR TITLE
Allow getting tracker data by key

### DIFF
--- a/lib/phoenix/tracker.ex
+++ b/lib/phoenix/tracker.ex
@@ -101,6 +101,7 @@ defmodule Phoenix.Tracker do
 
   @type presence :: {key :: String.t, meta :: Map.t}
   @type topic :: String.t
+  @type key :: term
 
   @callback init(Keyword.t) :: {:ok, pid} | {:error, reason :: term}
   @callback handle_diff(%{topic => {joins :: [presence], leaves :: [presence]}}, state :: term) :: {:ok, state :: term}
@@ -199,6 +200,31 @@ defmodule Phoenix.Tracker do
     |> GenServer.call({:list, topic})
     |> State.get_by_topic(topic)
     |> Enum.map(fn {{_topic, _pid, key},  meta, _tag} -> {key, meta} end)
+  end
+
+  @doc """
+  Retrieve a presence with a given key
+
+    * `server_name` - The registered name of the tracker server
+    * `key` - The key identifying this presence
+
+  Returns a presence's metadata.
+
+  ## Examples
+
+      iex> Phoenix.Tracker.get_by_key(MyTracker, 456)
+      %{name: "user 456"}
+  """
+  @spec get_by_key(atom, key) :: [presence]
+  def get_by_key(server_name, key) do
+    # TODO avoid extra map (ideally crdt does an ets select only returning {key, meta})
+    complete_record =
+      server_name
+      |> GenServer.call({:list, ""})
+      |> State.get_by_key(key)
+
+    {{_topic, _pid, _key}, meta, _tag} = complete_record
+    meta
   end
 
   @doc """

--- a/lib/phoenix/tracker/state.ex
+++ b/lib/phoenix/tracker/state.ex
@@ -117,6 +117,16 @@ defmodule Phoenix.Tracker.State do
     :ets.select(values, [{ {{topic, :_, :_}, :_, {:"$1", :_}},
       not_in(:"$1", replicas), [:"$_"]}])
   end
+
+  @spec get_by_key(t, key) :: [value]
+  def get_by_key(%State{values: values} = state, key) do
+    replicas = down_replicas(state)
+    case :ets.select(values, [{ {{:_, :_, key}, :_, {:"$1", :_}},
+      not_in(:"$1", replicas), [:"$_"]}]) do
+      [] -> %{}
+      [record | _] -> record
+    end
+  end
   defp not_in(_pos, []), do: []
   defp not_in(pos, replicas), do: [not: ors(pos, replicas)]
   defp ors(pos, [rep]), do: {:"==", pos, {rep}}

--- a/test/phoenix/tracker/integration_test.exs
+++ b/test/phoenix/tracker/integration_test.exs
@@ -22,6 +22,15 @@ defmodule Phoenix.Tracker.IntegrationTest do
     assert_heartbeat from: @primary
   end
 
+  test "getting by key",
+    %{tracker: tracker, topic: topic} do
+
+    {:ok, _ref} = Tracker.track(tracker, self(), topic, "me", %{name: "me"})
+
+    assert  %{name: "me", phx_ref: _} =
+      Tracker.get_by_key(tracker, "me")
+  end
+
   test "gossip from unseen node triggers nodeup and transfer request",
     %{tracker: tracker, topic: topic} do
 

--- a/test/phoenix/tracker/state_test.exs
+++ b/test/phoenix/tracker/state_test.exs
@@ -133,6 +133,57 @@ defmodule Phoenix.Tracker.StateTest do
     assert State.get_by_pid(state, pid, "notopic", "nokey") == nil
   end
 
+  test "get_by_key" do
+    pid = self()
+    state = new(:node1)
+    state2 = new(:node2)
+    state3 = new(:node3)
+    user2 = new_pid()
+    user3 = new_pid()
+
+    assert [] = State.get_by_topic(state, "topic")
+    state = State.join(state, pid, "topic", "key1", %{})
+    state = State.join(state, pid, "topic", "key2", %{})
+    state2 = State.join(state2, user2, "topic", "user2", %{})
+    state3 = State.join(state3, user3, "topic", "user3", %{})
+
+    # all replicas online
+    assert {{"topic", ^pid, "key1"}, %{}, {{:node1, 1}, 1}} =
+           State.get_by_key(state, "key1")
+    assert {{"topic", ^pid, "key2"}, %{}, {{:node1, 1}, 2}} =
+           State.get_by_key(state, "key2")
+
+    {state, _, _} = State.merge(state, State.extract(state2))
+    {state, _, _} = State.merge(state, State.extract(state3))
+    assert {{"topic", ^pid, "key1"}, %{}, {{:node1, 1}, 1}} =
+           State.get_by_key(state, "key1")
+    assert {{"topic", ^pid, "key2"}, %{}, {{:node1, 1}, 2}} =
+           State.get_by_key(state, "key2")
+    assert {{"topic", ^user2, "user2"}, %{}, {{:node2, 1}, 1}} =
+           State.get_by_key(state, "user2")
+    assert {{"topic", ^user3, "user3"}, %{}, {{:node3, 1}, 1}} =
+           State.get_by_key(state, "user3")
+
+    # one replica offline
+    {state, _, _} = State.replica_down(state, state2.replica)
+    assert {{"topic", ^pid, "key1"}, %{}, {{:node1, 1}, 1}} =
+           State.get_by_key(state, "key1")
+    assert {{"topic", ^pid, "key2"}, %{}, {{:node1, 1}, 2}} =
+           State.get_by_key(state, "key2")
+    assert {{"topic", ^user3, "user3"}, %{}, {{:node3, 1}, 1}} =
+           State.get_by_key(state, "user3")
+
+    # two replicas offline
+    {state, _, _} = State.replica_down(state, state3.replica)
+    assert {{"topic", ^pid, "key1"}, %{}, {{:node1, 1}, 1}} =
+           State.get_by_key(state, "key1")
+    assert {{"topic", ^pid, "key2"}, %{}, {{:node1, 1}, 2}} =
+           State.get_by_key(state, "key2")
+
+    assert %{} == State.get_by_key(state, "doesn't exist")
+  end
+
+
   test "get_by_topic" do
     pid = self()
     state = new(:node1)


### PR DESCRIPTION
`Phoenix.Tracker.get_by_key` allows us to request a specific piece of
data instead of traversing the whole list. I thought I would return an
empty map if we do not find the key in the list because it seemed like a
sane default to me. When I ask for a map I would like to receive one.

Amos King @adkron <amos@binarynoggin.com>