### PR TITLE
Fixed type for Tracker.init callback

### DIFF
--- a/lib/phoenix/tracker.ex
+++ b/lib/phoenix/tracker.ex
@@ -102,7 +102,7 @@ defmodule Phoenix.Tracker do
   @type presence :: {key :: String.t, meta :: Map.t}
   @type topic :: String.t
 
-  @callback init(Keyword.t) :: {:ok, pid} | {:error, reason :: term}
+  @callback init(Keyword.t) :: {:ok, state :: term} | {:error, reason :: term}
   @callback handle_diff(%{topic => {joins :: [presence], leaves :: [presence]}}, state :: term) :: {:ok, state :: term}
 
   ## Client


### PR DESCRIPTION
The tracker implementation is supposed to return `{:ok, state}` and not `{:ok, pid}`.

This change fixes dialyzer warnings in my own project that uses phoenix_pubsub.