### PR TITLE
Configurable broadcast strategy

### DIFF
--- a/lib/phoenix/pubsub/local.ex
+++ b/lib/phoenix/pubsub/local.ex
@@ -92,18 +92,19 @@ defmodule Phoenix.PubSub.Local do
       :ok
 
   """
-  def broadcast(fastlane, pubsub_server, 1 = _pool_size, from, topic, msg) when is_atom(pubsub_server) do
+
+  def broadcast(fastlane, pubsub_server, pool_size, from, topic, msg,
+    strategy \\ Phoenix.PubSub.Strategy.Parallel)
+  def broadcast(fastlane, pubsub_server, 1 = _pool_size, from, topic, msg, _)
+    when is_atom(pubsub_server) do
     do_broadcast(fastlane, pubsub_server, _shard = 0, from, topic, msg)
     :ok
   end
-  def broadcast(fastlane, pubsub_server, pool_size, from, topic, msg) when is_atom(pubsub_server) do
-    parent = self()
-    for shard <- 0..(pool_size - 1) do
-      Task.async(fn ->
-        do_broadcast(fastlane, pubsub_server, shard, from, topic, msg)
-        Process.unlink(parent)
-      end)
-    end |> Enum.map(&Task.await(&1, :infinity))
+  def broadcast(fastlane, pubsub_server, pool_size, from, topic, msg,
+    strategy) when is_atom(pubsub_server) do
+    strategy.broadcast(pool_size, fn(shard) ->
+      do_broadcast(fastlane, pubsub_server, shard, from, topic, msg)
+    end)
     :ok
   end
 

--- a/lib/phoenix/pubsub/local.ex
+++ b/lib/phoenix/pubsub/local.ex
@@ -102,7 +102,7 @@ defmodule Phoenix.PubSub.Local do
   end
   def broadcast(fastlane, pubsub_server, pool_size, from, topic, msg,
     strategy) when is_atom(pubsub_server) do
-    strategy.broadcast(pool_size, fn(shard) ->
+    strategy.run(pool_size, fn(shard) ->
       do_broadcast(fastlane, pubsub_server, shard, from, topic, msg)
     end)
     :ok

--- a/lib/phoenix/pubsub/pg2.ex
+++ b/lib/phoenix/pubsub/pg2.ex
@@ -33,9 +33,13 @@ defmodule Phoenix.PubSub.PG2 do
   def init([server, opts]) do
     scheduler_count = :erlang.system_info(:schedulers)
     pool_size = Keyword.get(opts, :pool_size, scheduler_count)
+    broadcast_strategy = Keyword.get(opts, :broadcast_strategy,
+      Phoenix.PubSub.Strategy.Parallel)
     node_name = opts[:node_name]
-    dispatch_rules = [{:broadcast, Phoenix.PubSub.PG2Server, [opts[:fastlane], server, pool_size]},
-                      {:direct_broadcast, Phoenix.PubSub.PG2Server, [opts[:fastlane], server, pool_size]},
+    dispatch_rules = [{:broadcast, Phoenix.PubSub.PG2Server,
+                       [opts[:fastlane], server, pool_size, broadcast_strategy]},
+                      {:direct_broadcast, Phoenix.PubSub.PG2Server,
+                       [opts[:fastlane], server, pool_size, broadcast_strategy]},
                       {:node_name, __MODULE__, [node_name]}]
 
     children = [

--- a/lib/phoenix/pubsub/pg2.ex
+++ b/lib/phoenix/pubsub/pg2.ex
@@ -22,6 +22,11 @@ defmodule Phoenix.PubSub.PG2 do
       topic or greater than 1M clients, a pool size equal to the number of
       schedulers (cores) is a well rounded size.
 
+    * `:broadcast_strategy` - What strategy to use for broadcasting messages.
+      Currently, `Phoenix.PubSub.Strategy.Parallel` is the default implementation.
+      For systems with very high broadcast throughput,
+      `Phoenix.PubSub.Strategy.Serial` may yield better performance.
+
   """
 
   def start_link(name, opts) do

--- a/lib/phoenix/pubsub/pg2_server.ex
+++ b/lib/phoenix/pubsub/pg2_server.ex
@@ -8,35 +8,35 @@ defmodule Phoenix.PubSub.PG2Server do
     GenServer.start_link __MODULE__, {server_name, pool_size}, name: server_name
   end
 
-  def direct_broadcast(fastlane, server_name, pool_size, broadcast_strategy,
+  def direct_broadcast(fastlane, server_name, pool_size, strategy,
     node_name, from_pid, topic, msg) do
     server_name
     |> get_members(node_name)
-    |> do_broadcast(fastlane, server_name, pool_size, from_pid, topic, msg, broadcast_strategy)
+    |> do_broadcast(fastlane, server_name, pool_size, from_pid, topic, msg, strategy)
   end
 
-  def broadcast(fastlane, server_name, pool_size, broadcast_strategy,
+  def broadcast(fastlane, server_name, pool_size, strategy,
     from_pid, topic, msg) do
     server_name
     |> get_members()
-    |> do_broadcast(fastlane, server_name, pool_size, from_pid, topic, msg, broadcast_strategy)
+    |> do_broadcast(fastlane, server_name, pool_size, from_pid, topic, msg, strategy)
   end
 
   defp do_broadcast({:error, {:no_such_group, _}}, _fastlane, _server,
     _pool, _from, _topic, _msg, _strategy) do
     {:error, :no_such_group}
   end
-  defp do_broadcast(pids, fastlane, server_name, pool_size, from_pid, topic, msg, broadcast_strategy)
+  defp do_broadcast(pids, fastlane, server_name, pool_size, from_pid, topic, msg, strategy)
     when is_list(pids) do
     local_node = Phoenix.PubSub.node_name(server_name)
 
     Enum.each(pids, fn
       pid when is_pid(pid) and node(pid) == node() ->
-        Local.broadcast(fastlane, server_name, pool_size, from_pid, topic, msg, broadcast_strategy)
+        Local.broadcast(fastlane, server_name, pool_size, from_pid, topic, msg, strategy)
       {^server_name, node_name} when node_name == local_node ->
-        Local.broadcast(fastlane, server_name, pool_size, from_pid, topic, msg, broadcast_strategy)
+        Local.broadcast(fastlane, server_name, pool_size, from_pid, topic, msg, strategy)
       pid_or_tuple ->
-        send(pid_or_tuple, {:forward_to_local, fastlane, from_pid, topic, msg, broadcast_strategy})
+        send(pid_or_tuple, {:forward_to_local, fastlane, from_pid, topic, msg, strategy})
     end)
     :ok
   end
@@ -49,10 +49,10 @@ defmodule Phoenix.PubSub.PG2Server do
     {:ok, %{name: server_name, pool_size: pool_size}}
   end
 
-  def handle_info({:forward_to_local, fastlane, from_pid, topic, msg, broadcast_strategy}, state) do
+  def handle_info({:forward_to_local, fastlane, from_pid, topic, msg, strategy}, state) do
     # The whole broadcast will happen inside the current process
     # but only for messages coming from the distributed system.
-    Local.broadcast(fastlane, state.name, state.pool_size, from_pid, topic, msg, broadcast_strategy)
+    Local.broadcast(fastlane, state.name, state.pool_size, from_pid, topic, msg, strategy)
     {:noreply, state}
   end
 

--- a/lib/phoenix/pubsub/strategy.ex
+++ b/lib/phoenix/pubsub/strategy.ex
@@ -1,0 +1,13 @@
+defmodule Phoenix.PubSub.Strategy do
+  @moduledoc """
+  Executes a number of tasks.
+
+  A `Strategy` implements the `run` callback, which takes a number `n`
+  and a fun, and applies the numbers `1..n` to the fun.
+
+  The particulars of how this is enacted are implementation-dependent.
+  """
+
+  @callback run(non_neg_integer, (non_neg_integer -> any)) :: :ok
+
+end

--- a/lib/phoenix/pubsub/strategy/parallel.ex
+++ b/lib/phoenix/pubsub/strategy/parallel.ex
@@ -1,0 +1,14 @@
+defmodule Phoenix.PubSub.Strategy.Parallel do
+
+  def broadcast(pool_size, fun) when is_function(fun, 1) do
+    parent = self()
+    for shard <- 0..(pool_size - 1) do
+      Task.async(fn ->
+        fun.(shard)
+        Process.unlink(parent)
+      end)
+    end |> Enum.map(&Task.await(&1, :infinity))
+    :ok
+  end
+
+end

--- a/lib/phoenix/pubsub/strategy/parallel.ex
+++ b/lib/phoenix/pubsub/strategy/parallel.ex
@@ -1,6 +1,18 @@
 defmodule Phoenix.PubSub.Strategy.Parallel do
+  @moduledoc """
+  Runs assigned tasks in parallel.
 
-  def broadcast(pool_size, fun) when is_function(fun, 1) do
+  This `Strategy` runs each task in a dedicated processes, using `Task.async`
+  and `Task.await`.
+
+  The call to `run` returns when all tasks have finished executing.
+
+  """
+
+  @behaviour Phoenix.PubSub.Strategy
+
+  @spec run(non_neg_integer, (non_neg_integer -> any)) :: :ok
+  def run(pool_size, fun) when is_function(fun, 1) do
     parent = self()
     for shard <- 0..(pool_size - 1) do
       Task.async(fn ->

--- a/lib/phoenix/pubsub/strategy/serial.ex
+++ b/lib/phoenix/pubsub/strategy/serial.ex
@@ -1,6 +1,16 @@
 defmodule Phoenix.PubSub.Strategy.Serial do
+  @moduledoc """
+  Runs assigned tasks serially.
 
-  def broadcast(pool_size, fun) when is_function(fun, 1) do
+  This `Strategy` runs assigned tasks one after another,
+  in the context of the calling process.
+
+  """
+
+  @behaviour Phoenix.PubSub.Strategy
+
+  @spec run(non_neg_integer, (non_neg_integer -> any)) :: :ok
+  def run(pool_size, fun) when is_function(fun, 1) do
     for shard <- 0..(pool_size - 1), do: fun.(shard)
     :ok
   end

--- a/lib/phoenix/pubsub/strategy/serial.ex
+++ b/lib/phoenix/pubsub/strategy/serial.ex
@@ -1,0 +1,8 @@
+defmodule Phoenix.PubSub.Strategy.Serial do
+
+  def broadcast(pool_size, fun) when is_function(fun, 1) do
+    for shard <- 0..(pool_size - 1), do: fun.(shard)
+    :ok
+  end
+
+end

--- a/test/phoenix/pubsub/local_test.exs
+++ b/test/phoenix/pubsub/local_test.exs
@@ -16,7 +16,8 @@ defmodule Phoenix.PubSub.LocalTest do
   end
 
   defmodule TestStrategy do
-    def broadcast(pool_size, fun), do: send(:calling_test, {pool_size, fun})
+    @behaviour Phoenix.PubSub.Strategy
+    def run(pool_size, fun), do: send(:calling_test, {pool_size, fun})
   end
 
   setup config do

--- a/test/phoenix/pubsub/strategy_test.exs
+++ b/test/phoenix/pubsub/strategy_test.exs
@@ -1,0 +1,26 @@
+defmodule Phoenix.PubSub.StrategyTest do
+  use ExUnit.Case, async: true
+
+  test "Serial strategy executes fun in the same process" do
+    test_pid = self()
+    fun = fn(shard) -> send(test_pid, {self(), shard}) end
+    Phoenix.PubSub.Strategy.Serial.broadcast(50, fun)
+    received_messages = for i <- 0..49 do
+      assert_received {_pid, ^i}
+    end
+    assert [_] = Enum.map(received_messages, &elem(&1, 0)) |> Enum.uniq
+  end
+
+  test "Parallel strategy executes fun in separate processes" do
+    test_pid = self()
+    fun = fn(shard) -> send(test_pid, {self(), shard}) end
+    Phoenix.PubSub.Strategy.Parallel.broadcast(50, fun)
+    received_messages = for i <- 0..49 do
+      assert_received {_pid, ^i}
+    end
+    assert 50 = Enum.map(received_messages, &elem(&1, 0))
+              |> Enum.uniq
+              |> Enum.count
+  end
+
+end

--- a/test/phoenix/pubsub/strategy_test.exs
+++ b/test/phoenix/pubsub/strategy_test.exs
@@ -4,7 +4,7 @@ defmodule Phoenix.PubSub.StrategyTest do
   test "Serial strategy executes fun in the same process" do
     test_pid = self()
     fun = fn(shard) -> send(test_pid, {self(), shard}) end
-    Phoenix.PubSub.Strategy.Serial.broadcast(50, fun)
+    Phoenix.PubSub.Strategy.Serial.run(50, fun)
     received_messages = for i <- 0..49 do
       assert_received {_pid, ^i}
     end
@@ -14,7 +14,7 @@ defmodule Phoenix.PubSub.StrategyTest do
   test "Parallel strategy executes fun in separate processes" do
     test_pid = self()
     fun = fn(shard) -> send(test_pid, {self(), shard}) end
-    Phoenix.PubSub.Strategy.Parallel.broadcast(50, fun)
+    Phoenix.PubSub.Strategy.Parallel.run(50, fun)
     received_messages = for i <- 0..49 do
       assert_received {_pid, ^i}
     end


### PR DESCRIPTION
# Configurable Broadcast Strategies for `Phoenix.PubSub.PG2`

## Summary

This work is a result of load tests conducted on a Phoenix system with the 
following characteristics:

  * Many (100K—300K) channels connected via websockets

  * Short channel lifetimes (0—300sec)

  * Large, one-sided channel subscriptions (1 to 100—500)  
      Implemented as internal subscriptions from one channel to multiple topics,
      *not* as channel-per-subscription.

Under the given constraints, we observed that the `pix_lock` and `proc_link` 
VM locks were acquired very often, resulting in lock contention. The BEAM virtual
machine became increasingly sluggish and ultimately unrensponsive as the number
of broadcasts issued went up.

We have determined that the code responsible for grabbing `pix_lock` and `proc_link`
is called from the [broadcast/6 function in Phoenix.PubSub.Local][1]. At 
sufficiently high load, the cost incurred by `Task.async` overwhelms the gains
to be had from parallelized broadcast. Lock counter statistics are provided below.

This problem is addressed by the `Phoenix.PubSub.Strategy` behaviour, which allows
the developer to select the manner in which broadcasts will be sent out to all the PubSub
pool member shards. The `Parallel` strategy does exactly what the original implementation
did, while the `Serial` strategy performs the broadcast sequentially to the shards, in numeric
order.

Using the `Serial` strategy lets the Phoenix PubSub system handle much higher
message rates. At very high loads, using the `Parallel` strategy can bring down
the system via lock contention, while the `Serial` strategy leaves the system
responsive.


## Comments & Caveats

We believe that the `Serial` strategy makes more sense for most applications of
real-time messaging with Phoenix PubSub, but this PR maintains `Parallel` as the
default implementation. This preserves compatibility with the existing codebase.

Furthermore, only `Phoenix.PubSub.PG2` leverages the choice of strategy. The Redis
pubsub module remains unaffected by any configuration changes.


## BEAM VM lock statistics for Parallel and Serial strategies

The below measurements were taken on a BEAM VM (Erlang/OTP 19.3) compiled with lock
counting capabilities (`--enable-lock-counter`). The Phoenix system was running the
application described above, with 100K channels, ~1.3K broadcasts/sec, on a
36-vCPU machine, with a PubSub `pool_size` of 36.

#### `Phoenix.PubSub.Strategy.Parallel` (the original PubSub.Local default)

```
lock             id    #tries  #collisions  collisions [%]  time [us]  duration [%]
-----           ---   ------- ------------ --------------- ---------- -------------
run_queue        36 106927778      4038734          3.7771   16127265       53.7447
pix_lock       1024    178959         3318          1.8541    6858644       22.8567
proc_link    149494  21039238       420852          2.0003    6051021       20.1652
proc_msgq    149494  40909368       129044          0.3154    2312437        7.7063
pollset           1    939200        60844          6.4783     498849        1.6624
drv_ev_state     16   1617956        23982          1.4822     281005        0.9365
```

#### `Phoenix.PubSub.Strategy.Serial`

```
lock             id    #tries  #collisions  collisions [%]  time [us]  duration [%]
-----           ---   ------- ------------ --------------- ---------- -------------
run_queue        36 115589890      6773095          5.8596   33032272      110.1032
proc_link    148354  20171968       245398          1.2165    1103565        3.6784
pollset           1    848509        66201          7.8020     531351        1.7711
drv_ev_state     16   1176528        28127          2.3907     364193        1.2139
proc_main    148354  49105560       305810          0.6228     198287        0.6609
db_hash_slot   4800  21299225         8677          0.0407      83465        0.2782
         
```

As evidenced by the graphs, omitting parallelism during broadcast frees up the BEAM 
VM to run its regularly-scheduled processes (the `run_queue` lock).
This directly translates to application responsiveness and capacity to handle load.


## Graphs from the application running under target production load

#### `Parallel` strategy
![image](https://cloud.githubusercontent.com/assets/344774/26313707/020d0850-3f0c-11e7-8598-e0bf426be247.png)

#### `Serial` strategy
![image](https://cloud.githubusercontent.com/assets/344774/26313710/066c5b76-3f0c-11e7-8525-edd86d8e61e0.png)

The graphs compare the same scenario executed using the `Parallel` and `Serial` strategies.   
The broadcast message rate was selected to show system behaviour under a heavy load,          
but not so heavy as to break the application.                                                 
                                                                                              
The system using the `Parallel` strategy is not completely unresponsive, but                  
some symptoms of overload are noticeable, such as higher tail latencies for                   
operations like Presence.track.                                                               
                                                                                              
The system using the `Serial` strategy displays much better tail latencies under              
the exact same load scenario.                                                                 


[1]: https://github.com/phoenixframework/phoenix_pubsub/blob/master/lib/phoenix/pubsub/local.ex#L99-L106
