### PR TITLE
Fix presence ghosting

### DIFF
--- a/lib/phoenix/tracker/delta_generation.ex
+++ b/lib/phoenix/tracker/delta_generation.ex
@@ -12,7 +12,7 @@ defmodule Phoenix.Tracker.DeltaGeneration do
   def extract(%State{mode: :normal} = state, generations, remote_ref, remote_context) do
     case delta_fullfilling_clock(generations, remote_context) do
       {delta, index} ->
-        if index, do: Logger.debug "#{inspect state.replica}: sending delta generation #{index + 1} #{Enum.count(delta.values)}"
+        if index, do: Logger.debug "#{inspect state.replica}: sending delta generation #{index + 1}"
         State.extract(delta, remote_ref, remote_context)
       nil ->
         Logger.debug "#{inspect state.replica}: falling back to sending entire crdt"
@@ -58,12 +58,8 @@ defmodule Phoenix.Tracker.DeltaGeneration do
     generations
     |> Enum.with_index()
     |> Enum.find(fn {%State{range: {local_start, local_end}}, _} ->
-      if Clock.dominates_or_equal?(remote_context, local_start) and
-         not Clock.dominates?(remote_context, local_end) do
-        true
-      else
-        false
-      end
+      Clock.dominates_or_equal?(remote_context, local_start) and
+        not Clock.dominates?(remote_context, local_end)
     end)
   end
 end

--- a/lib/phoenix/tracker/delta_generation.ex
+++ b/lib/phoenix/tracker/delta_generation.ex
@@ -9,14 +9,14 @@ defmodule Phoenix.Tracker.DeltaGeneration do
   Falls back to extracting entire crdt if unable to match delta.
   """
   @spec extract(State.delta, [State.delta], State.context) :: State.delta | State.t
-  def extract(%State{mode: :normal} = state, generations, remote_clock) do
-    case delta_fullfilling_clock(generations, remote_clock) do
+  def extract(%State{mode: :normal} = state, generations, remote_context) do
+    case delta_fullfilling_clock(generations, remote_context) do
       {delta, index} ->
         if index, do: Logger.debug "#{inspect state.replica}: sending delta generation #{index + 1}"
         delta
       nil ->
         Logger.debug "#{inspect state.replica}: falling back to sending entire crdt"
-        State.extract(state)
+        State.extract(state, remote_context)
     end
   end
 
@@ -54,11 +54,11 @@ defmodule Phoenix.Tracker.DeltaGeneration do
     end)
   end
 
-  defp delta_fullfilling_clock(generations, remote_clock) do
+  defp delta_fullfilling_clock(generations, remote_context) do
     generations
     |> Enum.with_index()
     |> Enum.find(fn {%State{range: {local_start, _local_end}}, _} ->
-      Clock.dominates?(remote_clock, local_start)
+      Clock.dominates?(remote_context, local_start)
     end)
   end
 end

--- a/lib/phoenix/tracker/state.ex
+++ b/lib/phoenix/tracker/state.ex
@@ -54,6 +54,7 @@ defmodule Phoenix.Tracker.State do
   def new(replica) do
     reset_delta(%State{
       replica: replica,
+      context: %{replica => 0},
       mode: :normal,
       values: :ets.new(:values, [:ordered_set]),
       pids: :ets.new(:pids, [:duplicate_bag]),
@@ -277,7 +278,7 @@ defmodule Phoenix.Tracker.State do
     end
   end
 
-  defp union_clouds(%State{mode: :delta, context: local_ctx} = local, %State{} = remote) do
+  defp union_clouds(%State{mode: :delta} = local, %State{} = remote) do
     Enum.reduce(remote.clouds, local.clouds, fn {name, remote_cloud}, acc ->
       Map.update(acc, name, remote_cloud, &MapSet.union(&1, remote_cloud))
     end)

--- a/test/phoenix/tracker/delta_generation_test.exs
+++ b/test/phoenix/tracker/delta_generation_test.exs
@@ -3,6 +3,12 @@ defmodule Phoenix.Tracker.DeltaGenerationTest do
   alias Phoenix.Tracker.{State, DeltaGeneration}
   import DeltaGeneration
 
+  def sorted_clouds(clouds) do
+    clouds
+    |> Enum.flat_map(fn {_name, cloud} -> Enum.to_list(cloud) end)
+    |> Enum.sort()
+  end
+
   defp new(node) do
     State.new(node)
   end
@@ -23,7 +29,7 @@ defmodule Phoenix.Tracker.DeltaGenerationTest do
     s1 = State.join(s1, new_pid(), "lobby", "user1", %{})
     assert [gen1, gen1, gen1] = gens = push(s1, [], s1.delta, [2, 5, 6])
     assert keys(gen1) == ["user1"]
-    assert Enum.to_list(gen1.cloud) == [{:s1, 1}]
+    assert sorted_clouds(gen1.clouds) == [{:s1, 1}]
     # dups merges have no effect
     assert [^gen1, ^gen1, ^gen1] = push(s1, gens, s1.delta, [2, 5, 6])
 
@@ -33,9 +39,9 @@ defmodule Phoenix.Tracker.DeltaGenerationTest do
     assert keys(gen1) == ["user2"]
     assert keys(gen2) == ["user1", "user2"]
     assert keys(gen3) == ["user1", "user2"]
-    assert Enum.sort(gen1.cloud) == [{:s1, 2}]
-    assert Enum.sort(gen2.cloud) == [{:s1, 1}, {:s1, 2}]
-    assert Enum.sort(gen3.cloud) == [{:s1, 1}, {:s1, 2}]
+    assert sorted_clouds(gen1.clouds) == [{:s1, 2}]
+    assert sorted_clouds(gen2.clouds) == [{:s1, 1}, {:s1, 2}]
+    assert sorted_clouds(gen3.clouds) == [{:s1, 1}, {:s1, 2}]
 
     s1 = State.reset_delta(s1)
     s1 = State.join(s1, new_pid(), "lobby", "user3", %{})
@@ -44,9 +50,9 @@ defmodule Phoenix.Tracker.DeltaGenerationTest do
     assert keys(gen1) == ["user3"]
     assert keys(gen2) == ["user2", "user3"]
     assert keys(gen3) == ["user1", "user2", "user3"]
-    assert Enum.sort(gen1.cloud) == [{:s1, 3}]
-    assert Enum.sort(gen2.cloud) == [{:s1, 2}, {:s1, 3}]
-    assert Enum.sort(gen3.cloud) == [{:s1, 1}, {:s1, 2}, {:s1, 3}]
+    assert sorted_clouds(gen1.clouds) == [{:s1, 3}]
+    assert sorted_clouds(gen2.clouds) == [{:s1, 2}, {:s1, 3}]
+    assert sorted_clouds(gen3.clouds) == [{:s1, 1}, {:s1, 2}, {:s1, 3}]
 
     s1 = State.reset_delta(s1)
     s1 = State.join(s1, new_pid(), "lobby", "user4", %{})
@@ -54,9 +60,9 @@ defmodule Phoenix.Tracker.DeltaGenerationTest do
     assert keys(gen1) == ["user4"]
     assert keys(gen2) == ["user3", "user4"]
     assert keys(gen3) == ["user2", "user3", "user4"]
-    assert Enum.sort(gen1.cloud) == [{:s1, 4}]
-    assert Enum.sort(gen2.cloud) == [{:s1, 3}, {:s1, 4}]
-    assert Enum.sort(gen3.cloud) == [{:s1, 2}, {:s1, 3}, {:s1, 4}]
+    assert sorted_clouds(gen1.clouds) == [{:s1, 4}]
+    assert sorted_clouds(gen2.clouds) == [{:s1, 3}, {:s1, 4}]
+    assert sorted_clouds(gen3.clouds) == [{:s1, 2}, {:s1, 3}, {:s1, 4}]
 
     # remote deltas
     user5 = new_pid()
@@ -65,9 +71,9 @@ defmodule Phoenix.Tracker.DeltaGenerationTest do
     assert keys(gen1) == ["user5"]
     assert keys(gen2) == ["user4", "user5"]
     assert keys(gen3) == ["user3", "user4", "user5"]
-    assert Enum.sort(gen1.cloud) == [{:s2, 1}]
-    assert Enum.sort(gen2.cloud) == [{:s1, 4}, {:s2, 1}]
-    assert Enum.sort(gen3.cloud) == [{:s1, 3}, {:s1, 4}, {:s2, 1}]
+    assert sorted_clouds(gen1.clouds) == [{:s2, 1}]
+    assert sorted_clouds(gen2.clouds) == [{:s1, 4}, {:s2, 1}]
+    assert sorted_clouds(gen3.clouds) == [{:s1, 3}, {:s1, 4}, {:s2, 1}]
 
     # tombstones
     s2 = State.leave(s2, user5)
@@ -75,9 +81,9 @@ defmodule Phoenix.Tracker.DeltaGenerationTest do
     assert keys(gen1) == []
     assert keys(gen2) == ["user4"]
     assert keys(gen3) == ["user3", "user4"]
-    assert Enum.sort(gen1.cloud) == [{:s2, 1}, {:s2, 2}]
-    assert Enum.sort(gen2.cloud) == [{:s1, 4}, {:s2, 1}, {:s2, 2}]
-    assert Enum.sort(gen3.cloud) == [{:s1, 3}, {:s1, 4}, {:s2, 1}, {:s2, 2}]
+    assert sorted_clouds(gen1.clouds) == [{:s2, 1}, {:s2, 2}]
+    assert sorted_clouds(gen2.clouds) == [{:s1, 4}, {:s2, 1}, {:s2, 2}]
+    assert sorted_clouds(gen3.clouds) == [{:s1, 3}, {:s1, 4}, {:s2, 1}, {:s2, 2}]
   end
 
   test "does not include non-contiguous deltas" do

--- a/test/phoenix/tracker/integration_test.exs
+++ b/test/phoenix/tracker/integration_test.exs
@@ -9,8 +9,8 @@ defmodule Phoenix.Tracker.IntegrationTest do
 
   setup config do
     tracker = config.test
-    {:ok, _pid} = start_tracker(name: tracker)
-    {:ok, topic: to_string(config.test), tracker: tracker}
+    {:ok, tracker_pid} = start_tracker(name: tracker)
+    {:ok, topic: to_string(config.test), tracker: tracker, tracker_pid: tracker_pid}
   end
 
   test "heartbeats", %{tracker: tracker} do
@@ -84,6 +84,36 @@ defmodule Phoenix.Tracker.IntegrationTest do
     assert_heartbeat from: @node2
 
     assert [{"node1", _}, {"node1.2", _}, {"node2", _}] = list(tracker, topic)
+  end
+
+  test "old pids from a node are permdowned when the node comes back up",
+    %{tracker: tracker, tracker_pid: tracker_pid, topic: topic} do
+    track_presence(@primary, tracker, self(), topic, @primary, %{})
+    {node1_node, {:ok, node1_tracker}} = start_tracker(@node1, name: tracker)
+    track_presence(@node1, tracker, node1_node, topic, @node1, %{})
+
+    spy_on_tracker(@node1, self(), tracker)
+    assert_heartbeat to: @node1, from: @primary
+
+    {node2_node, {:ok, node2_tracker}} = start_tracker(@node2, name: tracker)
+    track_presence(@node2, tracker, node2_node, topic, @node2, %{})
+
+    Process.unlink(node1_node)
+    Process.exit(node1_tracker, :kill)
+
+    spy_on_tracker(@node2, self(), tracker)
+
+    {node1_node_new, {:ok, node1_tracker}} = start_tracker(@node1, name: tracker)
+    track_presence(@node1, tracker, node1_node_new, topic, @node1, %{})
+
+    flush()
+    spy_on_tracker(@node1, self(), tracker)
+    assert_heartbeat to: @node2, from: @primary
+    assert_heartbeat to: @node1, from: @node2
+
+    refute {@node1, node1_node} in get_values(@primary, tracker_pid)
+    refute {@node1, node1_node} in get_values(@node1, node1_tracker)
+    refute {@node1, node1_node} in get_values(@node2, node2_tracker)
   end
 
   # TODO split into multiple testscases

--- a/test/phoenix/tracker/state_test.exs
+++ b/test/phoenix/tracker/state_test.exs
@@ -2,6 +2,12 @@ defmodule Phoenix.Tracker.StateTest do
   use ExUnit.Case, async: true
   alias Phoenix.Tracker.{State}
 
+  def sorted_clouds(clouds) do
+    clouds
+    |> Enum.flat_map(fn {_name, cloud} -> Enum.to_list(cloud) end)
+    |> Enum.sort()
+  end
+
   defp new(node) do
     State.new({node, 1})
   end
@@ -222,7 +228,7 @@ defmodule Phoenix.Tracker.StateTest do
     a = State.join(a, alice, "lobby", :alice)
     assert {b, [{{_, _, :alice}, _, _}], []} = State.merge(b, a.delta)
     assert {{:b, 1}, %{{:a, 1} => 3, {:b, 1} => 1}} = State.clocks(b)
-    assert Enum.empty?(b.cloud)
+    assert Enum.all?(Enum.map(b.clouds, fn {_, cloud} -> Enum.empty?(cloud) end))
   end
 
   test "merging deltas" do
@@ -243,7 +249,7 @@ defmodule Phoenix.Tracker.StateTest do
       {{:s2, 1}, 1} => {user2, "lobby", "user2", %{}},
       {{:s2, 1}, 2} => {user2, "private", "user2", %{}}
     }
-    assert Enum.sort(delta1.cloud) ==
+    assert sorted_clouds(delta1.clouds) ==
       [{{:s1, 1}, 1}, {{:s1, 1}, 2}, {{:s2, 1}, 1}, {{:s2, 1}, 2}]
   end
 
@@ -264,7 +270,7 @@ defmodule Phoenix.Tracker.StateTest do
       {{:s1, 1}, 1} => {user1, "lobby", "user1", %{}},
       {{:s1, 1}, 2} => {user1, "private", "user1", %{}},
     }
-    assert Enum.sort(delta1.cloud) ==
+    assert sorted_clouds(delta1.clouds) ==
       [{{:s1, 1}, 1}, {{:s1, 1}, 2}, {{:s2, 1}, 1}, {{:s2, 1}, 2}]
 
     # merging duplicates maintains delta
@@ -279,7 +285,7 @@ defmodule Phoenix.Tracker.StateTest do
       {{:s1, 1}, 1} => {user1, "lobby", "user1", %{}},
     }
     # maintains tombstone
-    assert Enum.sort(delta1.cloud) ==
+    assert sorted_clouds(delta1.clouds) ==
       [{{:s1, 1}, 1}, {{:s1, 1}, 2}, {{:s2, 1}, 1}, {{:s2, 1}, 2}, {{:s2, 1}, 3}]
   end
 end

--- a/test/phoenix/tracker/state_test.exs
+++ b/test/phoenix/tracker/state_test.exs
@@ -154,11 +154,11 @@ defmodule Phoenix.Tracker.StateTest do
     {state3, _, _} = State.replica_up(state3, {:node2, 1})
 
     assert state.context ==
-      %{{:node2, 1} => 0, {:node3, 1} => 0}
+      %{{:node2, 1} => 0, {:node3, 1} => 0, {:node1, 1} => 0}
     assert state2.context ==
-      %{{:node1, 1} => 0, {:node3, 1} => 0}
+      %{{:node1, 1} => 0, {:node3, 1} => 0, {:node2, 1} => 0}
     assert state3.context ==
-      %{{:node1, 1} => 0, {:node2, 1} => 0}
+      %{{:node1, 1} => 0, {:node2, 1} => 0, {:node3, 1} => 0}
 
     user2 = new_pid()
     user3 = new_pid()

--- a/test/phoenix/tracker/state_test.exs
+++ b/test/phoenix/tracker/state_test.exs
@@ -225,6 +225,8 @@ defmodule Phoenix.Tracker.StateTest do
   test "basic deltas" do
     a = new(:a)
     b = new(:b)
+    {a, _, _} = State.replica_up(a, b.replica)
+    {b, _, _} = State.replica_up(b, a.replica)
 
     alice = new_pid()
     bob = new_pid()
@@ -272,6 +274,8 @@ defmodule Phoenix.Tracker.StateTest do
   test "merging deltas with removes" do
     s1 = new(:s1)
     s2 = new(:s2)
+    {s1, _, _} = State.replica_up(s1, s2.replica)
+    {s2, _, _} = State.replica_up(s2, s1.replica)
     user1 = new_pid()
 
     # concurrent add wins

--- a/test/phoenix/tracker/state_test.exs
+++ b/test/phoenix/tracker/state_test.exs
@@ -26,7 +26,7 @@ defmodule Phoenix.Tracker.StateTest do
 
   test "that this is set up correctly" do
     a = new(:a)
-    assert {_a, map} = State.extract(a, a.context)
+    assert {_a, map} = State.extract(a, :a, a.context)
     assert map == %{}
   end
 
@@ -56,17 +56,17 @@ defmodule Phoenix.Tracker.StateTest do
     b = State.join(b, bob, "lobby", :bob)
 
     # Merging emits a bob join event
-    assert {a, [{{_, _, :bob}, _, _}], []} = State.merge(a, State.extract(b, a.context))
+    assert {a, [{{_, _, :bob}, _, _}], []} = State.merge(a, State.extract(b, :a, a.context))
     assert [:alice, :bob] = keys(State.online_list(a))
 
     # Merging twice doesn't dupe events
     pids_before = tab2list(a.pids)
-    assert {newa, [], []} = State.merge(a, State.extract(b, a.context))
+    assert {newa, [], []} = State.merge(a, State.extract(b, :a, a.context))
     assert newa == a
     assert pids_before == tab2list(newa.pids)
 
-    assert {b, [{{_, _, :alice}, _, _}], []} = State.merge(b, State.extract(a, b.context))
-    assert {^b, [], []} = State.merge(b, State.extract(a, b.context))
+    assert {b, [{{_, _, :alice}, _, _}], []} = State.merge(b, State.extract(a, :b, b.context))
+    assert {^b, [], []} = State.merge(b, State.extract(a, :b, b.context))
 
     # observe remove
     assert [{_, "lobby", :alice}, {_, "lobby", :bob}] = tab2list(a.pids)
@@ -74,17 +74,17 @@ defmodule Phoenix.Tracker.StateTest do
     assert [{_, "lobby", :bob}] = tab2list(a.pids)
     b_pids_before = tab2list(b.pids)
     assert [{_, "lobby", :alice}, {_, "lobby", :bob}] = b_pids_before
-    assert {b, [], [{{_, _, :alice}, _, _}]} = State.merge(b, State.extract(a, b.context))
+    assert {b, [], [{{_, _, :alice}, _, _}]} = State.merge(b, State.extract(a, :b, b.context))
     assert [{_, "lobby", :alice}] = b_pids_before -- tab2list(b.pids)
 
     assert [:bob] = keys(State.online_list(b))
-    assert {^b, [], []} = State.merge(b, State.extract(a, b.context))
+    assert {^b, [], []} = State.merge(b, State.extract(a, :b, b.context))
 
     b = State.join(b, carol, "lobby", :carol)
 
     assert [:bob, :carol] = keys(State.online_list(b))
-    assert {a, [{{_, _, :carol}, _, _}],[]} = State.merge(a, State.extract(b, a.context))
-    assert {^a, [], []} = State.merge(a, State.extract(b, a.context))
+    assert {a, [{{_, _, :carol}, _, _}],[]} = State.merge(a, State.extract(b, :a, a.context))
+    assert {^a, [], []} = State.merge(a, State.extract(b, :a, a.context))
 
     assert (State.online_list(b) |> Enum.sort) == (State.online_list(a) |> Enum.sort)
   end
@@ -103,7 +103,7 @@ defmodule Phoenix.Tracker.StateTest do
     a = State.join(a, alice, "lobby", :alice)
     b = State.join(b, bob, "lobby", :bob)
 
-    {a, [{{_, _, :bob}, _, _}], _} = State.merge(a, State.extract(b, a.context))
+    {a, [{{_, _, :bob}, _, _}], _} = State.merge(a, State.extract(b, :a, a.context))
 
     assert [:alice, :bob] = a |> State.online_list() |> keys()
 
@@ -115,7 +115,7 @@ defmodule Phoenix.Tracker.StateTest do
 
     assert [:carol, :david] = keys(State.online_list(a))
 
-    assert {a,[],[]} = State.merge(a, State.extract(b, a.context))
+    assert {a,[],[]} = State.merge(a, State.extract(b, :a, a.context))
     assert [:carol, :david] = keys(State.online_list(a))
 
     assert {a,[{{_, _, :bob}, _, _}],[]} = State.replica_up(a, {:b,1})
@@ -174,8 +174,8 @@ defmodule Phoenix.Tracker.StateTest do
             {{"topic", ^pid, "key2"}, %{}, {{:node1, 1}, 2}}] =
            State.get_by_topic(state, "topic")
 
-    {state, _, _} = State.merge(state, State.extract(state2, state.context))
-    {state, _, _} = State.merge(state, State.extract(state3, state.context))
+    {state, _, _} = State.merge(state, State.extract(state2, :node1, state.context))
+    {state, _, _} = State.merge(state, State.extract(state3, :node1, state.context))
     assert [{{"topic", ^pid, "key1"}, %{}, {{:node1, 1}, 1}},
             {{"topic", ^pid, "key2"}, %{}, {{:node1, 1}, 2}},
             {{"topic", ^user2, "user2"}, %{}, {{:node2, 1}, 1}},
@@ -209,7 +209,7 @@ defmodule Phoenix.Tracker.StateTest do
 
     state1 = State.join(state1, alice, "lobby", :alice)
     state2 = State.join(state2, bob, "lobby", :bob)
-    {state2, _, _} = State.merge(state2, State.extract(state1, state2.context))
+    {state2, _, _} = State.merge(state2, State.extract(state1, :node2, state2.context))
     assert keys(State.online_list(state2)) == [:alice, :bob]
 
     {state2, _, _} = State.replica_down(state2, {:node1, 1})

--- a/test/support/node_case.ex
+++ b/test/support/node_case.ex
@@ -142,6 +142,16 @@ defmodule Phoenix.PubSub.NodeCase do
     end
   end
 
+  def get_values(node, tracker) do
+    table = :sys.get_state(tracker).presences.values
+    {_, vals} = call_node(node, fn -> get_values(table) end)
+    Enum.map(vals, fn [{{_, pid, node}, _, _}] -> {node, pid} end)
+  end
+
+  def get_values(table) do
+    :ets.match(table, :"$1")
+  end
+
   defp call_node(node, func) do
     parent = self()
     ref = make_ref()


### PR DESCRIPTION
@gazler this includes the test cases from your branch that re-create the ghosting issues. I've changed the way replication is done to only extract and transfer presences within the remote node's context, so we avoid replicating presences that may be raced in a permdown. Everything looks good on my end with my own applications. Can you run it through its paces locally and verify on your end with the scenarios you've done preivously? Thanks!

Chris