### PR TITLE
do_broadcast loops over pubsub shards without spawning Tasks

### DIFF
--- a/lib/phoenix/pubsub/local.ex
+++ b/lib/phoenix/pubsub/local.ex
@@ -97,13 +97,9 @@ defmodule Phoenix.PubSub.Local do
     :ok
   end
   def broadcast(fastlane, pubsub_server, pool_size, from, topic, msg) when is_atom(pubsub_server) do
-    parent = self()
     for shard <- 0..(pool_size - 1) do
-      Task.async(fn ->
-        do_broadcast(fastlane, pubsub_server, shard, from, topic, msg)
-        Process.unlink(parent)
-      end)
-    end |> Enum.map(&Task.await(&1, :infinity))
+      do_broadcast(fastlane, pubsub_server, shard, from, topic, msg)
+    end
     :ok
   end
 

--- a/test/support/node_case.ex
+++ b/test/support/node_case.ex
@@ -1,5 +1,5 @@
 defmodule Phoenix.PubSub.NodeCase do
-  @timeout 500
+  @timeout 1000
   @heartbeat 100
   @permdown 1500
   @pubsub Phoenix.PubSub.Test.PubSub


### PR DESCRIPTION
Do not use `Task.async` and `wait` when calling `do_broadcast` on pubsub pool shards.

The supporting documentation & rationale is supplied with #78, which should be ignored in favor of this PR.