### PR TITLE
Fix Dialyzer warnings

### DIFF
--- a/lib/phoenix/tracker/delta_generation.ex
+++ b/lib/phoenix/tracker/delta_generation.ex
@@ -8,7 +8,7 @@ defmodule Phoenix.Tracker.DeltaGeneration do
 
   Falls back to extracting entire crdt if unable to match delta.
   """
-  @spec extract(State.delta, [State.delta], State.name, State.context) :: State.delta | State.t
+  @spec extract(State.t, [State.delta], State.name, State.context) :: State.delta | State.t
   def extract(%State{mode: :normal} = state, generations, remote_ref, remote_context) do
     case delta_fullfilling_clock(generations, remote_context) do
       {delta, index} ->

--- a/lib/phoenix/tracker/replica.ex
+++ b/lib/phoenix/tracker/replica.ex
@@ -3,13 +3,13 @@ defmodule Phoenix.Tracker.Replica do
   alias Phoenix.Tracker.Replica
 
   @type name :: String.t
-  @type vsn :: term
+  @type vsn :: integer
   @type replica_ref :: {name, vsn}
 
   @type t :: %Replica{
     name: name,
     vsn: vsn,
-    last_heartbeat_at: pos_integer,
+    last_heartbeat_at: pos_integer | nil,
     status: :up | :down | :permdown
   }
 
@@ -77,9 +77,13 @@ defmodule Phoenix.Tracker.Replica do
     %Replica{replica | last_heartbeat_at: now_ms()}
   end
 
-  defp now_ms, do: System.system_time(:milli_seconds)
+  @otp_vsn :erlang.system_info(:otp_release) |> :erlang.list_to_integer()
+  @time_unit_ms if @otp_vsn < 19, do: :milli_seconds, else: :milliseconds
+  @time_unis_us if @otp_vsn < 19, do: :micro_seconds, else: :microseconds
+
+  defp now_ms, do: System.system_time(@time_unit_ms)
 
   defp unique_vsn do
-    System.system_time(:micro_seconds) + System.unique_integer([:positive])
+    System.system_time(@time_unis_us) + System.unique_integer([:positive])
   end
 end

--- a/lib/phoenix/tracker/state.ex
+++ b/lib/phoenix/tracker/state.ex
@@ -7,8 +7,8 @@ defmodule Phoenix.Tracker.State do
   @type name       :: term
   @type topic      :: String.t
   @type key        :: term
-  @type meta       :: Map.t
-  @type ets_id     :: pos_integer
+  @type meta       :: map
+  @type ets_id     :: :ets.tid
   @type clock      :: pos_integer
   @type tag        :: {name, clock}
   @type cloud      :: MapSet.t
@@ -175,7 +175,8 @@ defmodule Phoenix.Tracker.State do
 
   Used when merging two sets.
   """
-  @spec extract(t, remote_ref :: name, context) :: {t, values}
+
+  @spec extract(t, remote_ref :: name, context) :: t | {t, values}
   def extract(%State{mode: :delta, values: values, clouds: clouds} = state, remote_ref, remote_context) do
     {start_ctx, end_ctx} = state.range
     known_keys = Map.keys(remote_context)
@@ -251,7 +252,7 @@ defmodule Phoenix.Tracker.State do
     end)
   end
 
-  @spec observe_removes(t, t, [value]) :: {clouds, delta, leaves :: [value]}
+  @spec observe_removes(t, t, map) :: {clouds, delta, leaves :: [value]}
   defp observe_removes(%State{pids: pids, values: values} = local, remote, remote_map) do
     unioned_clouds = union_clouds(local, remote)
     init = {unioned_clouds, local.delta, []}

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,2 @@
-%{"dialyze": {:hex, :dialyze, "0.2.1", "9fb71767f96649020d769db7cbd7290059daff23707d6e851e206b1fdfa92f9d", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.11.5", "0dc51cb84f8312162a2313d6c71573a9afa332333d8a332bb12540861b9834db", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]}}
+%{"dialyze": {:hex, :dialyze, "0.2.1", "9fb71767f96649020d769db7cbd7290059daff23707d6e851e206b1fdfa92f9d", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.11.5", "0dc51cb84f8312162a2313d6c71573a9afa332333d8a332bb12540861b9834db", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, repo: "hexpm", optional: true]}], "hexpm"}}


### PR DESCRIPTION
After running Dialyzer on Elixir 1.4/OTP 20 with `--unknown` flag,
39 warnings have been emitted. This commit fixes all those warnings,
although it required introducing private type `Tracker.state`.