### PR TITLE
Fix doc typos in Phoenix.PubSub and Phoenix.PubSub.PG2

### DIFF
--- a/lib/phoenix/pubsub.ex
+++ b/lib/phoenix/pubsub.ex
@@ -131,7 +131,7 @@ defmodule Phoenix.PubSub do
       `%Phoenix.Socket.Broadcast{}` events. The fastlane process is
       notified of a cached message instead of the normal subscriber.
       Fastlane handlers must implement `fastlane/1` callbacks which accepts
-      a `Phoenix.Socket.Broadcast` structs and returns a fastlaned format
+      a `Phoenix.Socket.Broadcast` struct and returns a fastlaned format
       for the handler. For example:
 
           PubSub.subscribe(MyApp.PubSub, "topic1",

--- a/lib/phoenix/pubsub/pg2.ex
+++ b/lib/phoenix/pubsub/pg2.ex
@@ -12,7 +12,7 @@ defmodule Phoenix.PubSub.PG2 do
 
   ## Options
 
-    * `:name` - The registered name and optional node name to for the PubSub
+    * `:name` - The registered name and optional node name for the PubSub
       processes, for example: `MyApp.PubSub`, `{MyApp.PubSub, :node@host}`.
       When only a server name is provided, the node name defaults to `node()`.
 


### PR DESCRIPTION
This PR fixes a couple of documentation typos.