### PR TITLE
Fix the child_spec for PG2: the start tuple needs the arguments to be a list

### DIFF
--- a/lib/phoenix/pubsub/pg2.ex
+++ b/lib/phoenix/pubsub/pg2.ex
@@ -37,7 +37,7 @@ defmodule Phoenix.PubSub.PG2 do
 
     %{
       id: __MODULE__,
-      start: {__MODULE__, :start_link, opts},
+      start: {__MODULE__, :start_link, [opts]},
       type: :supervisor
     }
   end
@@ -53,7 +53,8 @@ defmodule Phoenix.PubSub.PG2 do
 
   defp name!(opts) do
     case Keyword.fetch(opts, :name) do
-      {:ok, name} -> name
+      {:ok, name} ->
+        name
 
       :error ->
         raise ArgumentError, """
@@ -81,16 +82,19 @@ defmodule Phoenix.PubSub.PG2 do
     scheduler_count = :erlang.system_info(:schedulers)
     pool_size = Keyword.get(opts, :pool_size, scheduler_count)
     node_name = opts[:node_name]
-    dispatch_rules = [{:broadcast, Phoenix.PubSub.PG2Server, [opts[:fastlane], server, pool_size]},
-                      {:direct_broadcast, Phoenix.PubSub.PG2Server, [opts[:fastlane], server, pool_size]},
-                      {:node_name, __MODULE__, [node_name]}]
+
+    dispatch_rules = [
+      {:broadcast, Phoenix.PubSub.PG2Server, [opts[:fastlane], server, pool_size]},
+      {:direct_broadcast, Phoenix.PubSub.PG2Server, [opts[:fastlane], server, pool_size]},
+      {:node_name, __MODULE__, [node_name]}
+    ]
 
     children = [
       supervisor(Phoenix.PubSub.LocalSupervisor, [server, pool_size, dispatch_rules]),
-      worker(Phoenix.PubSub.PG2Server, [server, pool_size]),
+      worker(Phoenix.PubSub.PG2Server, [server, pool_size])
     ]
 
-    supervise children, strategy: :rest_for_one
+    supervise(children, strategy: :rest_for_one)
   end
 
   @doc false

--- a/test/phoenix/pubsub/pg2_test.exs
+++ b/test/phoenix/pubsub/pg2_test.exs
@@ -1,6 +1,6 @@
 # Run shared PubSub adapter tests
 Application.put_env(:phoenix, :pubsub_test_adapter, Phoenix.PubSub.PG2)
-Code.require_file "../../shared/pubsub_test.exs", __DIR__
+Code.require_file("../../shared/pubsub_test.exs", __DIR__)
 
 # Run distributed elixir specific PubSub tests
 defmodule Phoenix.PubSub.PG2Test do
@@ -31,7 +31,7 @@ defmodule Phoenix.PubSub.PG2Test do
     test "with just a name returns the name" do
       spec = PG2.child_spec(name: :fred)
       assert %{id: PG2, type: :supervisor, start: start} = spec
-      assert {PG2, :start_link, [name: :fred]} == start
+      assert {PG2, :start_link, [[name: :fred]]} == start
     end
 
     test "requires name" do
@@ -43,25 +43,27 @@ defmodule Phoenix.PubSub.PG2Test do
     test "with a compound name returns the name" do
       spec = PG2.child_spec(name: {:fred, :node99})
       assert %{id: PG2, type: :supervisor, start: start} = spec
-      assert {PG2, :start_link, [name: {:fred, :node99}]} == start
+      assert {PG2, :start_link, [[name: {:fred, :node99}]]} == start
     end
 
     test "with a name and options returns both" do
       spec = PG2.child_spec(name: :fred, pool_size: 3)
       assert %{id: PG2, type: :supervisor, start: start} = spec
-      assert {PG2, :start_link, [name: :fred, pool_size: 3]} == start
+      assert {PG2, :start_link, [[name: :fred, pool_size: 3]]} == start
     end
   end
 
   describe "with running server" do
     setup config do
       size = config[:pool_size] || 1
+
       if config[:pool_size] do
         {:ok, _} = PG2.start_link(config.test, pool_size: size)
       else
         {:ok, _} = PG2.start_link(config.test, [])
       end
-      {_, {:ok, _}} = start_pubsub(@node1, PG2, config.test, [pool_size: size * 2])
+
+      {_, {:ok, _}} = start_pubsub(@node1, PG2, config.test, pool_size: size * 2)
       {:ok, %{pubsub: config.test, pool_size: size}}
     end
 
@@ -103,13 +105,15 @@ defmodule Phoenix.PubSub.PG2Test do
 
     test "pool size defaults to number of schedulers" do
       {:ok, pg2_supervisor} = PG2.start_link(:pool_size_count_test, [])
+
       local_supervisor =
         pg2_supervisor
         |> Supervisor.which_children()
         |> Enum.find_value(fn
-            {Phoenix.PubSub.LocalSupervisor, pid, :supervisor, _} -> pid
-            _                                                     -> false
-          end)
+          {Phoenix.PubSub.LocalSupervisor, pid, :supervisor, _} -> pid
+          _ -> false
+        end)
+
       %{supervisors: supervisor_count} = Supervisor.count_children(local_supervisor)
       assert supervisor_count == :erlang.system_info(:schedulers)
     end


### PR DESCRIPTION
This should fix errors when starting the PG2 PubSub through:
```ex
  children = [
      {Phoenix.PubSub.PG2, name: MyApp.PubSub},
	...
  ]
```
with resulting:
```
** (Mix) Could not start application MyApp: MyApp.Application.start(:normal, []) returned an error: shutdown: failed to start child: Phoenix.PubSub.PG2
    ** (EXIT) an exception was raised:
        ** (FunctionClauseError) no function clause matching in Phoenix.PubSub.PG2.start_link/1
            (phoenix_pubsub) lib/phoenix/pubsub/pg2.ex:45: Phoenix.PubSub.PG2.start_link({:name, MyApp.PubSub})
            (stdlib) supervisor.erl:365: :supervisor.do_start_child/2
            (stdlib) supervisor.erl:348: :supervisor.start_children/3
            (stdlib) supervisor.erl:314: :supervisor.init_children/2
            (stdlib) gen_server.erl:365: :gen_server.init_it/2
            (stdlib) gen_server.erl:333: :gen_server.init_it/6
            (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
```