### PR TITLE
Fix deprecation warnings on Elixir 1.7.0

### DIFF
--- a/lib/phoenix/tracker/replica.ex
+++ b/lib/phoenix/tracker/replica.ex
@@ -77,9 +77,9 @@ defmodule Phoenix.Tracker.Replica do
     %Replica{replica | last_heartbeat_at: now_ms()}
   end
 
-  defp now_ms, do: System.system_time(:milli_seconds)
+  defp now_ms, do: System.system_time(:millisecond)
 
   defp unique_vsn do
-    System.system_time(:micro_seconds) + System.unique_integer([:positive])
+    System.system_time(:microsecond) + System.unique_integer([:positive])
   end
 end


### PR DESCRIPTION
Elixir 1.7.0 requires the use of singular non-underscored time units.

Included in this commit:

https://github.com/elixir-lang/elixir/commit/94f3d60a262c1ca11547fd0f7395d2875faa261e