### PR TITLE
Don't choose empty deltas when extracting earliest delta from state

### DIFF
--- a/lib/phoenix/tracker/delta_generation.ex
+++ b/lib/phoenix/tracker/delta_generation.ex
@@ -58,7 +58,8 @@ defmodule Phoenix.Tracker.DeltaGeneration do
     generations
     |> Enum.with_index()
     |> Enum.find(fn {%State{range: {local_start, local_end}}, _} ->
-      Clock.dominates_or_equal?(remote_context, local_start) and
+      not Clock.dominates_or_equal?(local_start, local_end) and
+        Clock.dominates_or_equal?(remote_context, local_start) and
         not Clock.dominates?(remote_context, local_end)
     end)
   end


### PR DESCRIPTION
This fixes an edge case that we hit when doing initial (without netsplits and concurrent updates) property based testing of the Tracker [here](https://github.com/distributed-owls/breaking-pp/blob/master/test/large/cluster_counterexamples_test.exs#L6-L35).

Note that the counterexample has been further shrunken manually, and seems to be a minimal one -- connecting less than 52 users to the node 2 makes the test pass.

After some analysis, and to my best understanding, it seems that this test reproduces a condition when an empty delta (range `from` is equal to `to`) is on the list of generations on node 1.
Then node 2 wants to get a delta from node 1, but hasn't seen any version of data from node 1 yet, therefore node 1 is not included in the remote context during the delta extraction.
As a result, the empty delta is extracted, because this empty delta's clock dominates the remote context's clock.

A minimal example of the situation described above is reproduced in the `an empty delta is not extracted` test.
That's probably the best starting point in order to verify if the above theory makes any sense at all :)

cc @pzel 