### PR TITLE
Choose delta dominating on common set of replicas

### DIFF
--- a/lib/phoenix/tracker/clock.ex
+++ b/lib/phoenix/tracker/clock.ex
@@ -71,6 +71,15 @@ defmodule Phoenix.Tracker.Clock do
     Map.merge(c1, c2, fn _, v1, v2 -> min(v1, v2) end)
   end
 
+  @doc """
+  Returns the clock with just provided replicas.
+  """
+  def filter_replicas(c, replicas), do: Map.take(c, replicas)
+
+  @doc """
+  Returns replicas from the given clock.
+  """
+  def replicas(c), do: Map.keys(c)
 
   defp filter_clocks(clockset, {node, clock}) do
     clockset

--- a/lib/phoenix/tracker/delta_generation.ex
+++ b/lib/phoenix/tracker/delta_generation.ex
@@ -58,6 +58,9 @@ defmodule Phoenix.Tracker.DeltaGeneration do
     generations
     |> Enum.with_index()
     |> Enum.find(fn {%State{range: {local_start, local_end}}, _} ->
+      local_start = Clock.filter_replicas(local_start, Clock.replicas(remote_context))
+      local_end = Clock.filter_replicas(local_end, Clock.replicas(remote_context))
+
       not Clock.dominates_or_equal?(local_start, local_end) and
         Clock.dominates_or_equal?(remote_context, local_start) and
         not Clock.dominates?(remote_context, local_end)

--- a/lib/phoenix/tracker/delta_generation.ex
+++ b/lib/phoenix/tracker/delta_generation.ex
@@ -58,7 +58,8 @@ defmodule Phoenix.Tracker.DeltaGeneration do
     generations
     |> Enum.with_index()
     |> Enum.find(fn {%State{range: {local_start, local_end}}, _} ->
-      Clock.dominates_or_equal?(remote_context, local_start) and
+      not Clock.dominates_or_equal?(local_start, local_end) and
+        Clock.dominates_or_equal?(remote_context, local_start) and
         not Clock.dominates?(remote_context, local_end)
     end)
   end

--- a/test/phoenix/tracker/clock_test.exs
+++ b/test/phoenix/tracker/clock_test.exs
@@ -42,4 +42,17 @@ defmodule Phoenix.TrackerClockTest do
     assert Clock.lowerbound(%{}, %{a: 3, b: 1, d: 2}) == %{a: 3, b: 1, d: 2}
     assert Clock.lowerbound(%{a: 3, b: 1, d: 2}, %{}) == %{a: 3, b: 1, d: 2}
   end
+
+  test "filter replicas" do
+    assert Clock.filter_replicas(%{a: 1, b: 2, c: 3}, [:a, :b]) == %{a: 1, b: 2}
+    assert Clock.filter_replicas(%{a: 1, b: 2, c: 3}, [:a, :c]) == %{a: 1, c: 3}
+    assert Clock.filter_replicas(%{a: 1, b: 2, c: 3}, [:a, :d]) == %{a: 1}
+    assert Clock.filter_replicas(%{a: 1, b: 2, c: 3}, [:d]) == %{}
+  end
+
+  test "replicas" do
+    assert Clock.replicas(%{}) == []
+    assert Clock.replicas(%{a: 1}) == [:a]
+    assert Clock.replicas(%{a: 1, b: 2}) == [:a, :b]
+  end
 end

--- a/test/phoenix/tracker/delta_generation_test.exs
+++ b/test/phoenix/tracker/delta_generation_test.exs
@@ -153,4 +153,19 @@ defmodule Phoenix.Tracker.DeltaGenerationTest do
 
     assert DeltaGeneration.extract(s3, [d2, d3], :r3, %{r2: 0}) == expected_delta
   end
+
+  test "delta that isn't dominating on common set of replicas is not extracted", config do
+    pid = new_pid()
+    s1 = new(:r1, config)
+    s2 = State.join(s1, pid, "lobby", "user1", %{})
+    d1 = s2.delta
+
+    s3 = State.join(s2, pid, "lobby", "user2", %{})
+    d2 = s3.delta
+
+    {d1_left, d1_right} = d1.range
+    d1 = %{d1 | range: {Map.put(d1_left, :r2, 0), Map.put(d1_right, :r2, 1)}}
+
+    assert DeltaGeneration.extract(s3, [d1, d2], :r3, %{r1: 1}) == d2
+  end
 end

--- a/test/phoenix/tracker/state_test.exs
+++ b/test/phoenix/tracker/state_test.exs
@@ -149,7 +149,7 @@ defmodule Phoenix.Tracker.StateTest do
     state = State.join(state, pid2, "topic", "key1", %{device: :ios})
     state = State.join(state, pid2, "topic", "key2", %{device: :ios})
 
-    assert [{^pid, %{device: :browser}}, {pid2, %{device: :ios}}] =
+    assert [{^pid, %{device: :browser}}, {_pid2, %{device: :ios}}] =
            State.get_by_key(state, "topic", "key1")
 
     assert State.get_by_key(state, "another_topic", "key1") == []


### PR DESCRIPTION
This is done on top of #108. 

This fixes [this counterexample](https://github.com/distributed-owls/breaking-pp/blob/ee49fb7d8c2cad155a1d1d6ae382340f7e091e80/test/large/cluster_counterexamples_test.exs#L40-L64), which to my understanding is caused by the following inconsistency:

* `DeltaGeneration.extract/4` can choose a delta with a clock containing a non-zero version from some node;
* `State.extract/3` then removes all values from delta, coming from a replica that the replica that asked for a delta didn't know about (doesn't have it in its remote context);
* This (empty) delta will always be chosen if it's on the list of deltas.

The `delta that isn't dominating on common set of replicas is not extracted` is a minimal test demonstrating this condition.

cc @pzel 
