### PR TITLE
Fix `Phoenix.Tracker` example implementation in module docs

### DIFF
--- a/lib/phoenix/tracker.ex
+++ b/lib/phoenix/tracker.ex
@@ -59,7 +59,7 @@ defmodule Phoenix.Tracker do
 
         def start_link(opts) do
           opts = Keyword.merge([name: __MODULE__], opts)
-          GenServer.start_link(Phoenix.Tracker, [__MODULE__, opts, opts], name: __MODULE__)
+          Phoenix.Tracker.start_link(__MODULE__, opts, opts)
         end
 
         def init(opts) do


### PR DESCRIPTION
Since v1.1.0 the example `MyTracker` implementation given in the `Phoenix.Tracker` module docs does not work. When you attempt to start the `MyTracker` process an error is returned:

```console
iex> Phoenix.PubSub.PG2.start_link(name: MyPubSub)
{:ok, #PID<0.211.0>}

iex> MyTracker.start_link(pubsub_server: MyPubSub)
** (EXIT from #PID<0.176.0>) shell process exited with reason: an exception was raised:
    ** (FunctionClauseError) no function clause matching in Phoenix.Tracker.init/1
        (phoenix_pubsub) lib/phoenix/tracker.ex:260: Phoenix.Tracker.init([MyTracker, [name: MyTracker, pubsub_server: MyPubSub], [name: MyTracker, pubsub_server: MyPubSub]])
        (stdlib) gen_server.erl:374: :gen_server.init_it/2
        (stdlib) gen_server.erl:342: :gen_server.init_it/6
        (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
```

An additional `name` argument was added to the `Phoenix.tracker.init` function in [commit `bcca203a8b65daee367ebbe9ec843fd822eeb981#`](https://github.com/phoenixframework/phoenix_pubsub/commit/bcca203a8b65daee367ebbe9ec843fd822eeb981diff-fc3d1e8efd95176c339eaafe5ab24ad6R240).

Changing `GenServer.start_link/3` to `Phoenix.Tracker.start_link/3` resolves the issue allowing the tracker to be used:

```console
iex> Phoenix.PubSub.PG2.start_link(name: MyPubSub)
{:ok, #PID<0.210.0>}
iex> MyTracker.start_link(pubsub_server: MyPubSub)
{:ok, #PID<0.251.0>}
iex> Phoenix.Tracker.track(MyTracker, self(), "lobby", "Ben", %{})
presence join: key "Ben" with meta %{phx_ref: "1MY8eMssK7Y="}
{:ok, "1MY8eMssK7Y="}
iex> Phoenix.Tracker.list(MyTracker, "lobby")
[{"Ben", %{phx_ref: "1MY8eMssK7Y="}}]
```
