### PR TITLE
Improve replication over netsplit

### DIFF
--- a/lib/phoenix/tracker/clock.ex
+++ b/lib/phoenix/tracker/clock.ex
@@ -71,6 +71,15 @@ defmodule Phoenix.Tracker.Clock do
     Map.merge(c1, c2, fn _, v1, v2 -> min(v1, v2) end)
   end
 
+  @doc """
+  Returns the clock with just provided replicas.
+  """
+  def filter_replicas(c, replicas), do: Map.take(c, replicas)
+
+  @doc """
+  Returns replicas from the given clock.
+  """
+  def replicas(c), do: Map.keys(c)
 
   defp filter_clocks(clockset, {node, clock}) do
     clockset

--- a/lib/phoenix/tracker/delta_generation.ex
+++ b/lib/phoenix/tracker/delta_generation.ex
@@ -58,6 +58,9 @@ defmodule Phoenix.Tracker.DeltaGeneration do
     generations
     |> Enum.with_index()
     |> Enum.find(fn {%State{range: {local_start, local_end}}, _} ->
+      local_start = Clock.filter_replicas(local_start, Clock.replicas(remote_context))
+      local_end = Clock.filter_replicas(local_end, Clock.replicas(remote_context))
+
       not Clock.dominates_or_equal?(local_start, local_end) and
         Clock.dominates_or_equal?(remote_context, local_start) and
         not Clock.dominates?(remote_context, local_end)

--- a/lib/phoenix/tracker/delta_generation.ex
+++ b/lib/phoenix/tracker/delta_generation.ex
@@ -58,7 +58,8 @@ defmodule Phoenix.Tracker.DeltaGeneration do
     generations
     |> Enum.with_index()
     |> Enum.find(fn {%State{range: {local_start, local_end}}, _} ->
-      Clock.dominates_or_equal?(remote_context, local_start) and
+      not Clock.dominates_or_equal?(local_start, local_end) and
+        Clock.dominates_or_equal?(remote_context, local_start) and
         not Clock.dominates?(remote_context, local_end)
     end)
   end

--- a/lib/phoenix/tracker/state.ex
+++ b/lib/phoenix/tracker/state.ex
@@ -358,7 +358,10 @@ defmodule Phoenix.Tracker.State do
     %{values: local_values, range: {local_start, local_end}, context: local_context, clouds: local_clouds} = local
     %{range: {remote_start, remote_end}, context: remote_context, clouds: remote_clouds} = remote
 
-    if Clock.dominates_or_equal?(local_end, remote_start) do
+    if (Clock.dominates_or_equal?(remote_end, local_start) and
+        Clock.dominates_or_equal?(local_end, remote_start)) or
+       (Clock.dominates_or_equal?(local_end, remote_start) and
+        Clock.dominates_or_equal?(remote_end, local_start)) do
       new_start = Clock.lowerbound(local_start, remote_start)
       new_end = Clock.upperbound(local_end, remote_end)
       clouds = union_clouds(local, remote)

--- a/lib/phoenix/tracker/state.ex
+++ b/lib/phoenix/tracker/state.ex
@@ -233,7 +233,9 @@ defmodule Phoenix.Tracker.State do
     %State{state | values: map, clouds: pruned_clouds, range: {pruned_start, pruned_end}}
   end
   def extract(%State{mode: :normal, values: values, clouds: clouds} = state, remote_ref, remote_context) do
-    pruned_clouds = Map.take(clouds, Map.keys(remote_context))
+    known_keys = Map.keys(remote_context)
+    pruned_clouds = Map.take(clouds, known_keys)
+    pruned_context = Map.take(state.context, known_keys)
     # fn {{topic, pid, key}, meta, {replica, clock}} when replica !== remote_ref ->
     #  {{replica, clock}, {pid, topic, key, meta}}
     # end
@@ -251,7 +253,12 @@ defmodule Phoenix.Tracker.State do
         end
       end)
 
-    {%State{state | clouds: pruned_clouds, pids: nil, values: nil, delta: :unset}, Map.new(data)}
+    {%State{state |
+        clouds: pruned_clouds,
+        context: pruned_context,
+        pids: nil,
+        values: nil,
+        delta: :unset}, Map.new(data)}
   end
 
   @doc """

--- a/test/phoenix/tracker/clock_test.exs
+++ b/test/phoenix/tracker/clock_test.exs
@@ -42,4 +42,17 @@ defmodule Phoenix.TrackerClockTest do
     assert Clock.lowerbound(%{}, %{a: 3, b: 1, d: 2}) == %{a: 3, b: 1, d: 2}
     assert Clock.lowerbound(%{a: 3, b: 1, d: 2}, %{}) == %{a: 3, b: 1, d: 2}
   end
+
+  test "filter replicas" do
+    assert Clock.filter_replicas(%{a: 1, b: 2, c: 3}, [:a, :b]) == %{a: 1, b: 2}
+    assert Clock.filter_replicas(%{a: 1, b: 2, c: 3}, [:a, :c]) == %{a: 1, c: 3}
+    assert Clock.filter_replicas(%{a: 1, b: 2, c: 3}, [:a, :d]) == %{a: 1}
+    assert Clock.filter_replicas(%{a: 1, b: 2, c: 3}, [:d]) == %{}
+  end
+
+  test "replicas" do
+    assert Clock.replicas(%{}) == []
+    assert Clock.replicas(%{a: 1}) == [:a]
+    assert Clock.replicas(%{a: 1, b: 2}) == [:a, :b]
+  end
 end

--- a/test/phoenix/tracker/delta_generation_test.exs
+++ b/test/phoenix/tracker/delta_generation_test.exs
@@ -153,4 +153,19 @@ defmodule Phoenix.Tracker.DeltaGenerationTest do
 
     assert DeltaGeneration.extract(s3, [d2, d3], :r3, %{r2: 0}) == expected_delta
   end
+
+  test "delta that isn't dominating on common set of replicas is not extracted", config do
+    pid = new_pid()
+    s1 = new(:r1, config)
+    s2 = State.join(s1, pid, "lobby", "user1", %{})
+    d1 = s2.delta
+
+    s3 = State.join(s2, pid, "lobby", "user2", %{})
+    d2 = s3.delta
+
+    {d1_left, d1_right} = d1.range
+    d1 = %{d1 | range: {Map.put(d1_left, :r2, 0), Map.put(d1_right, :r2, 1)}}
+
+    assert DeltaGeneration.extract(s3, [d1, d2], :r3, %{r1: 1}) == d2
+  end
 end

--- a/test/phoenix/tracker/state_test.exs
+++ b/test/phoenix/tracker/state_test.exs
@@ -149,7 +149,7 @@ defmodule Phoenix.Tracker.StateTest do
     state = State.join(state, pid2, "topic", "key1", %{device: :ios})
     state = State.join(state, pid2, "topic", "key2", %{device: :ios})
 
-    assert [{^pid, %{device: :browser}}, {pid2, %{device: :ios}}] =
+    assert [{^pid, %{device: :browser}}, {_pid2, %{device: :ios}}] =
            State.get_by_key(state, "topic", "key1")
 
     assert State.get_by_key(state, "another_topic", "key1") == []

--- a/test/phoenix/tracker/state_test.exs
+++ b/test/phoenix/tracker/state_test.exs
@@ -306,6 +306,16 @@ defmodule Phoenix.Tracker.StateTest do
     assert Enum.all?(Enum.map(b.clouds, fn {_, cloud} -> Enum.empty?(cloud) end))
   end
 
+  test "deltas are not merged for non-contiguous ranges", config do
+    s1 = new(:s1, config)
+    s2 = State.join(s1, new_pid(), "lobby", "user1", %{})
+    s3 = State.join(s2, new_pid(), "lobby", "user2", %{})
+    s4 = State.join(State.reset_delta(s3), new_pid(), "lobby", "user3", %{})
+
+    assert State.merge_deltas(s2.delta, s4.delta) == {:error, :not_contiguous}
+    assert State.merge_deltas(s4.delta, s2.delta) == {:error, :not_contiguous}
+  end
+
   test "merging deltas", config do
     s1 = new(:s1, config)
     s2 = new(:s2, config)


### PR DESCRIPTION
This is done on top of #108 and #109.

This PR is an attempt to fix issues discovered by the property based tests that can generate split and join network between certain nodes:

1. [This counterexample](https://github.com/distributed-owls/breaking-pp/blob/master/test/large/cluster_counterexamples_test.exs#L66-L95) reproduced a case when joins are propagated via netsplit (node 1 stores information about sessions connected to node 3 internally), but leaves are not -- when the node 3 sessions are disconnected and the split is healed, these sessions still appear to be connected on node 1.
The proposed solution makes the filter in `observe_removes` less strict. I'm not sure what performance implications this might have, though.

2. [This counterexample](https://github.com/distributed-owls/breaking-pp/blob/master/test/large/cluster_counterexamples_test.exs#L97-L153) occasionally reproduces a situation when some of the sessions connected to node 3 never appear on node 2.
It seems that sometimes a merge of two deltas was possible, when their ranges were not contiguous. The proposed solution makes the deltas adjacency check more strict.

cc @pzel