### PR TITLE
Fix documentation (DocTest) for Phoenix.PubSub

### DIFF
--- a/lib/phoenix/pubsub.ex
+++ b/lib/phoenix/pubsub.ex
@@ -49,12 +49,12 @@ defmodule Phoenix.PubSub do
 
       iex> PubSub.subscribe :my_pubsub, "user:123"
       :ok
-      iex> Process.info(self())[:messages]
-      []
+      iex> Process.info(self(), :messages)
+      {:messages, []}
       iex> PubSub.broadcast :my_pubsub, "user:123", {:user_update, %{id: 123, name: "Shane"}}
       :ok
-      iex> Process.info(self())[:messages]
-      {:user_update, %{id: 123, name: "Shane"}}
+      iex> Process.info(self(), :messages)
+      {:messages, [{:user_update, %{id: 123, name: "Shane"}}]}
 
   ## Implementing your own adapter
 


### PR DESCRIPTION
Use `Process.info(self(), :messages)` instead of `Process.info(self())[:messages]`.
The later one was returning an empty array for me every time.

Issue appeared with Phoenix PubSub 1.1.1, Elixir 1.7.4, Erlang/OTP 21 [erts-10.1.1]