### PR TITLE
Use random_ref instead of make_ref for transfer_req

### DIFF
--- a/lib/phoenix/tracker/shard.ex
+++ b/lib/phoenix/tracker/shard.ex
@@ -347,7 +347,7 @@ defmodule Phoenix.Tracker.Shard do
 
   defp request_transfer(state, {name, _vsn}) do
     log state, fn -> "#{state.replica.name}: transfer_req from #{name}" end
-    ref = make_ref()
+    ref = random_ref()
     msg = {:pub, :transfer_req, ref, Replica.ref(state.replica), clock(state)}
     direct_broadcast(state, name, msg)
   end


### PR DESCRIPTION
Hi, 

We have own implementation of direct_broadcast protocol and we have a bug in production with a transfer of transfer_req presence events. 

Server1 when sending does:
```
binary_transfer_req_msg = 
  transfer_req_msg
  |> :erlang.term_to_binary()
  |> Base.encode64!()
```
Server2 when receiving event:
```
event = 
  binary_transfer_req_msg
  |> Base.decode64!()
  |> :erlang.binary_to_term([:safe])
```
Now I'm getting ArgumentError since references can't be safely deserialized. The solution is to use something more safe for this ref. By the way, what is the purpose of this ref? It isn't used in transfer_ack.
  
