### PR TITLE
Clarify `broadcast_from` documentation

### DIFF
--- a/lib/phoenix/pubsub.ex
+++ b/lib/phoenix/pubsub.ex
@@ -150,6 +150,7 @@ defmodule Phoenix.PubSub do
 
   @doc """
   Broadcasts message on given topic from the given process across the whole cluster.
+  Sent to all subscribers of a topic, excluding the process described by `from`.
 
     * `pubsub` - The name of the pubsub system
     * `from` - The pid that will send the message


### PR DESCRIPTION
When reading the docs of `broadcast_from`, there is no real difference from `broadcast`. Would be nice to indicate when to use which function more clearly.

Suggestions welcome.