### PR TITLE
Fix the phoenix tracker doc formatting

### DIFF
--- a/lib/phoenix/tracker.ex
+++ b/lib/phoenix/tracker.ex
@@ -20,8 +20,8 @@ defmodule Phoenix.Tracker do
 
   ## Required `pool_opts`:
 
-    * `:name` - The name of the server, such as: `MyApp.Tracker`
-                This will also form the common prefix for all shard names
+    * `:name` - The name of the server, such as: `MyApp.Tracker`. This will also
+      form the common prefix for all shard names
     * `:pubsub_server` - The name of the PubSub server, such as: `MyApp.PubSub`
 
   ## Optional `pool_opts`:


### PR DESCRIPTION
What it looks right now on [hexdocs.pm](https://hexdocs.pm/phoenix_pubsub/Phoenix.Tracker.html#module-required-pool_opts):

<img width="878" alt="image" src="https://user-images.githubusercontent.com/1198528/98907074-3a63ae80-24f9-11eb-9242-985b0bd73ae0.png">

After:

<img width="890" alt="image" src="https://user-images.githubusercontent.com/1198528/98907164-641cd580-24f9-11eb-9fd8-388db904da0d.png">
