### PR TITLE
Add helpful moduledoc to Phoenix.PubSub.Cluster

### DIFF
--- a/test/support/cluster.ex
+++ b/test/support/cluster.ex
@@ -1,4 +1,9 @@
 defmodule Phoenix.PubSub.Cluster do
+  @moduledoc """
+  A helper module for testing distributed code.
+  Requires `epmd` to be running in order to work:
+  `$ epmd -daemon`
+  """
 
   def spawn(nodes) do
     # Turn node into a distributed node with the given long name


### PR DESCRIPTION
This module has been helpful to me as a guide for writing similar distributed test helpers in several projects, but I've run into issues related to `epmd` not running in the past and forgotten that was the problem/solution. Maybe I'm not alone? Either way, a helpful moduledoc would prevent that in the future!