### PR TITLE
Add `Phoenix.PubSub.is_running?/0`

### DIFF
--- a/lib/phoenix/pubsub.ex
+++ b/lib/phoenix/pubsub.ex
@@ -289,7 +289,7 @@ defmodule Phoenix.PubSub do
   end
 
   @doc """
-  Returns `true` if Phoenix PubSub has been started, otherwise it returns false.
+  Returns `true` if Phoenix PubSub has been started, otherwise it returns `false`.
   """
   def is_running? do
     started_applications = Application.started_applications() |> Enum.map(&elem(&1, 0))

--- a/lib/phoenix/pubsub.ex
+++ b/lib/phoenix/pubsub.ex
@@ -34,7 +34,7 @@ defmodule Phoenix.PubSub do
       It supports a `:pool_size` option to be given alongside
       the name, defaults to `1`. Note the `:pool_size` must
       be the same throughout the cluster, therefore don't
-      configure the pool size based on `System.schedulers_online/1`, 
+      configure the pool size based on `System.schedulers_online/1`,
       especially if you are using machines with different specs.
 
     * `Phoenix.PubSub.Redis` - uses Redis to exchange data between
@@ -286,6 +286,14 @@ defmodule Phoenix.PubSub do
     end
 
     :ok
+  end
+
+  @doc """
+  Returns `true` if Phoenix PubSub has been started, otherwise it returns false.
+  """
+  def is_running? do
+    started_applications = Application.started_applications() |> Enum.map(&elem(&1, 0))
+    :phoenix_pubsub in started_applications
   end
 
   defp dispatch(pubsub, from, topic, message, dispatcher) do

--- a/lib/phoenix/pubsub.ex
+++ b/lib/phoenix/pubsub.ex
@@ -289,11 +289,13 @@ defmodule Phoenix.PubSub do
   end
 
   @doc """
-  Returns `true` if Phoenix PubSub has been started, otherwise it returns `false`.
+  Returns `true` if the provided PubSub has been started, otherwise it returns `false`.
+
+  ## Example
+    iex> is_started?(MyApp.PubSub)
   """
-  def is_running? do
-    started_applications = Application.started_applications() |> Enum.map(&elem(&1, 0))
-    :phoenix_pubsub in started_applications
+  def is_started?(pubsub) do
+    Enum.member?(Process.registered(), pubsub)
   end
 
   defp dispatch(pubsub, from, topic, message, dispatcher) do


### PR DESCRIPTION
# What is this?

`Phoenix.PubSub.is_started?()` gets the list of registered processes and checks if the provided `pubsub` is in the list.

# Why is this useful?

I am sinfully using PubSub in a GenServer module before PubSub is started. For this, I will repent later, but I needed this function and it seems useful. I couldn't find a way to check PubSub's status without crashing the app (using Supervisor, Application, Registry functions).

Some of my module's functions broadcast when they're called, but the app crashes if PubSub hasn't been started. So, I needed a way to conditionally broadcast messages only if PubSub was running.

# For example

As a temporary solution, I have added a helper to my Application module.

## MyApp.Application

```elixir
def is_pubsub_started?(pubsub) do
  Enum.member?(Process.registered(), pubsub)
end
```

\* The function name is `is_started?` in this PR.

## MyApp.Users

```elixir
def add_user(user) do
  ...
  if MyApp.Application.is_pubsub_started?(MyApp.PubSub) do
    PubSub.broadcast(MyApp.PubSub, @topic, {:user_added, user})
  end
end
```

# Ideal Usage

```elixir
def add_user(user) do
  ...
  if PubSub.is_started?(MyApp.PubSub) do
    PubSub.broadcast(MyApp.PubSub, @topic, {:user_added, user})
  end
end
```

# Feedback

I am open to feedback, even if this feature is deemed out of scope for PubSub. Yes, I will move PubSub out of my User module, I promise. 😇

Thank you for maintaining this. 🫂