### PR TITLE
Make it clear that `PG2` is not related to Postgres

### DIFF
--- a/lib/phoenix/pubsub/pg2.ex
+++ b/lib/phoenix/pubsub/pg2.ex
@@ -3,6 +3,10 @@ defmodule Phoenix.PubSub.PG2 do
   Phoenix PubSub adapter based on `:pg`/`:pg2`.
 
   It runs on Distributed Erlang and is the default adapter.
+  
+  Please note that `pg` stands for "Process Group" (an Erlang module).
+
+  This PubSub adapter is in no way related to Postgres, the database.
   """
 
   @behaviour Phoenix.PubSub.Adapter


### PR DESCRIPTION
Recently working on a multi-node app which is not yet an Elixir cluster, I somehow assumed that the `PG2` adapter would help me broadcast from one node to another, and it took a bit of time & Slack exchanges to realise that `PG2` is in no way related to Postgres.

The confusion probably stems from the fact that `pg` is, for a number of popular stacks (Ruby, Javascript), the name of the client library for Postgres.

### Remaining tasks

- [ ] Add a blurb here https://hexdocs.pm/phoenix_pubsub/Phoenix.PubSub.html#module-adapters too