### PR TITLE
Update ETS atomically on tracker update

### DIFF
--- a/test/phoenix/tracker/state_test.exs
+++ b/test/phoenix/tracker/state_test.exs
@@ -87,6 +87,17 @@ defmodule Phoenix.Tracker.StateTest do
     assert {^a, [], []} = State.merge(a, State.extract(b, a.replica, a.context))
 
     assert (State.online_list(b) |> Enum.sort) == (State.online_list(a) |> Enum.sort)
+
+    # update
+    b = State.leave_join(b, carol, "lobby", :carol, %{updated: true})
+    pids_before = tab2list(a.pids)
+
+    assert {a, [{{_, _, :carol}, %{updated: true}, _}], [{{_, _, :carol}, _, _}]} =
+      State.merge(a, State.extract(b, a.replica, a.context))
+
+    assert {^a, [], []} = State.merge(a, State.extract(b, a.replica, a.context))
+
+    assert pids_before == tab2list(a.pids)
   end
 
   test "basic netsplit", config do


### PR DESCRIPTION
Tracker update is handled as leave + join and ETS updates are applied in this notion, that is, a delete followed by an insert. Since tracker lookup reads ETS on the caller side, it can happen concurrently to tracker update, so there is a race condition when the ETS read happens between said delete and insert.

The "values" ETS table (which keeps the metadata) is an :ordered_set, which means that we can do an atomic update just by inserting the new value, without prior delete. So I made two changes:

  * for the local case I added `State.leave_join`, which works just like `State.leave` + `State.join`, but without the unnecessary delete
  * for the remote case I updated `State.merge` to gather desired inserts/deletes to ETS, do a simple diff and only then apply the changes (which makes an entry update atomic)

The changes only affect applying changes to the internal ETS storage, the update is reported as leave + join in exactly the same way.

Context: in Livebook we use tracker for registering notebook session processes and we also store basic session information necessary for listing, which gets updated. We have a lot of tests that create and lookup sessions and we started to observe more and more intermittent test failures that basically go: create session -> lookup session -> session not found. Running tests in a loop I could reproduce this behaviour and tracked it down to this race condition, with this PR it no longer happens.