### PR TITLE
Only allow update if pid is on current node

### DIFF
--- a/lib/phoenix/tracker/shard.ex
+++ b/lib/phoenix/tracker/shard.ex
@@ -531,6 +531,9 @@ defmodule Phoenix.Tracker.Shard do
     """
   end
 
+  defp handle_update({pid, _topic, _key, _meta_updater}, state) when node(pid) != node(), 
+    do: {:reply, {:error, :not_owner}, state}
+  
   defp handle_update({pid, topic, key, meta_updater}, state) do
     case State.get_by_pid(state.presences, pid, topic, key) do
       nil ->


### PR DESCRIPTION
To the best of my knowledge, `Phoenix.Tracker.update/5` should not be used to update presence metadata for processes that are on a separate node. If you do this, Bad Things will happen. Ask me how I know. 

So, this PR adds a safeguard against this.

Returning `{:error, :nopresence}` might also be acceptable here for backwards-compatibility, at the cost of an error reason that isn't really accurate.

I did my best to implement the test case, but I couldn't follow 100% what is going on, so there may be a better way to set it up.