### PR TITLE
Fix: call State.new/2 with 2 args in bench and docs

### DIFF
--- a/lib/phoenix/tracker/state.ex
+++ b/lib/phoenix/tracker/state.ex
@@ -47,7 +47,7 @@ defmodule Phoenix.Tracker.State do
 
   ## Examples
 
-      iex> Phoenix.Tracker.State.new(:replica1)
+      iex> Phoenix.Tracker.State.new(:replica1, :shard_name)
       %Phoenix.Tracker.State{...}
 
   """

--- a/script/bench.exs
+++ b/script/bench.exs
@@ -18,12 +18,11 @@ defmodule Bench do
     topic_size = trunc(size / 10)
 
     {s1, s2} = time "Creating 2 #{size} element sets", fn ->
-      s1 = Enum.reduce(1..size, State.new(:s1), fn i, acc ->
-
+      s1 = Enum.reduce(1..size, State.new(:s1, :shard1), fn i, acc ->
         State.join(acc, make_ref(), "topic#{:erlang.phash2(i, topic_size)}", "user#{i}", %{name: i})
       end)
 
-      s2 = Enum.reduce(1..size, State.new(:s2), fn i, acc ->
+      s2 = Enum.reduce(1..size, State.new(:s2, :shard2), fn i, acc ->
         State.join(acc, make_ref(), "topic#{i}", "user#{i}", %{name: i})
       end)
 


### PR DESCRIPTION
The bench script was failing with:
```elixir
** (UndefinedFunctionError) function Phoenix.Tracker.State.new/1 is undefined or private. Did you mean:

      * new/2
 ```
 
 So I tried to fix it.
 
 Thank you for reviewing.