### PR TITLE
Minor/fixes

### DIFF
--- a/lib/phoenix/pubsub.ex
+++ b/lib/phoenix/pubsub.ex
@@ -226,7 +226,7 @@ defmodule Phoenix.PubSub do
   A custom dispatcher may also be given as a fifth, optional argument.
   See the "Custom dispatching" section in the module documentation.
   """
-  @spec direct_broadcast(t, topic, message, dispatcher) :: :ok | {:error, term}
+  @spec direct_broadcast(node_name, t, topic, message, dispatcher) :: :ok | {:error, term}
   def direct_broadcast(node_name, pubsub, topic, message, dispatcher \\ __MODULE__)
       when is_atom(pubsub) and is_binary(topic) and is_atom(dispatcher) do
     {:ok, {adapter, name}} = Registry.meta(pubsub, :pubsub)

--- a/lib/phoenix/tracker/state.ex
+++ b/lib/phoenix/tracker/state.ex
@@ -47,7 +47,7 @@ defmodule Phoenix.Tracker.State do
 
   ## Examples
 
-      iex> Phoenix.Tracker.State.new(:replica1)
+      iex> Phoenix.Tracker.State.new(:replica1, :shard_name)
       %Phoenix.Tracker.State{...}
 
   """

--- a/script/bench.exs
+++ b/script/bench.exs
@@ -18,12 +18,12 @@ defmodule Bench do
     topic_size = trunc(size / 10)
 
     {s1, s2} = time "Creating 2 #{size} element sets", fn ->
-      s1 = Enum.reduce(1..size, State.new(:s1), fn i, acc ->
+      s1 = Enum.reduce(1..size, State.new(node(), :s1), fn i, acc ->
 
         State.join(acc, make_ref(), "topic#{:erlang.phash2(i, topic_size)}", "user#{i}", %{name: i})
       end)
 
-      s2 = Enum.reduce(1..size, State.new(:s2), fn i, acc ->
+      s2 = Enum.reduce(1..size, State.new(node(), :s2), fn i, acc ->
         State.join(acc, make_ref(), "topic#{i}", "user#{i}", %{name: i})
       end)
 


### PR DESCRIPTION
1. Typespec fix.
2. Fix State.new documentation and usages. Should the spec change from `@spec new(name, atom)` [here](https://github.com/phoenixframework/phoenix_pubsub/blob/main/lib/phoenix/tracker/state.ex#L55) to something more clear? It's not clear to me what name and atom stand for here.