### PR TITLE
Only restart shards if they terminate unexpectedly

### DIFF
--- a/lib/phoenix/tracker.ex
+++ b/lib/phoenix/tracker.ex
@@ -327,7 +327,8 @@ defmodule Phoenix.Tracker do
 
         %{
           id: shard_name,
-          start: {Phoenix.Tracker.Shard, :start_link, [tracker, tracker_opts, shard_opts]}
+          start: {Phoenix.Tracker.Shard, :start_link, [tracker, tracker_opts, shard_opts]},
+          restart: :transient
         }
       end
 


### PR DESCRIPTION
Fixes https://github.com/phoenixframework/phoenix_pubsub/issues/194

This ensures the Supervisor doesn't restart Shards that we're trying to shut down using `Phoenix.Tracker.graceful_permdown/1`