### PR TITLE
Introduce broadcast_pool_size option to allow safe pool size migration

### DIFF
--- a/lib/phoenix/pubsub/pg2.ex
+++ b/lib/phoenix/pubsub/pg2.ex
@@ -74,13 +74,13 @@ defmodule Phoenix.PubSub.PG2 do
   @impl true
   def init({name, adapter_name, pool_size, broadcast_pool_size}) do
 
-    receiving_groups = groups(adapter_name, pool_size)
+    listener_groups = groups(adapter_name, pool_size)
     broadcast_groups = groups(adapter_name, broadcast_pool_size)
 
     :persistent_term.put(adapter_name, List.to_tuple(broadcast_groups))
 
     children =
-      for group <- receiving_groups do
+      for group <- listener_groups do
         Supervisor.child_spec({Phoenix.PubSub.PG2Worker, {name, group}}, id: group)
       end
 

--- a/test/phoenix/distributed_pubsub_test.exs
+++ b/test/phoenix/distributed_pubsub_test.exs
@@ -49,16 +49,16 @@ defmodule Phoenix.PubSub.DistributedTest do
     refute_received {@node1, :ping}
   end
 
-  test "broadcast is received by other node that has running_pool_size > broadcast_pool_size", config do
+  test "broadcast is received by other node that has pool_size > broadcast_pool_size", config do
     spy_on_pubsub(@node1, config.pubsub, self(), config.topic)
-    # node3 has running_pool_size = 4, broadcast_pool_size = 1
+    # node3 has pool_size = 4, broadcast_pool_size = 1
     spy_on_pubsub(@node3, config.pubsub, self(), config.topic)
     :ok = PubSub.broadcast(config.pubsub, config.topic, :ping)
     assert_receive {@node3, :ping}
   end
 
   test "broadcast is received by other node that was broadcast from node that has broadcast_pool_size < pool_size", config do
-    # node4 has pool_size = 1, message is sent from node3 that has running_pool_size = 4, broadcast_pool_size = 1
+    # node4 has pool_size = 1, message is sent from node3 that has pool_size = 4, broadcast_pool_size = 1
     spy_on_pubsub(@node1, config.pubsub, self(), config.topic)
     spy_on_pubsub(@node2, config.pubsub, self(), config.topic)
     spy_on_pubsub(@node3, config.pubsub, self(), config.topic)

--- a/test/phoenix/distributed_pubsub_test.exs
+++ b/test/phoenix/distributed_pubsub_test.exs
@@ -5,6 +5,8 @@ defmodule Phoenix.PubSub.DistributedTest do
 
   @node1 :"node1@127.0.0.1"
   @node2 :"node2@127.0.0.1"
+  @node3 :"node3@127.0.0.1"
+  @node4 :"node4@127.0.0.1"
 
   setup config do
     {:ok, %{pubsub: Phoenix.PubSubTest, topic: Atom.to_string(config.test)}}
@@ -17,7 +19,7 @@ defmodule Phoenix.PubSub.DistributedTest do
     :ok = PubSub.broadcast(config.pubsub, config.topic, :ping)
     assert_receive {@node1, :ping}
     assert_receive {@node2, :ping}
-    
+
     :ok = PubSub.broadcast(config.pubsub, config.topic, :ping)
     assert_receive {@node1, :ping}
     assert_receive {@node2, :ping}
@@ -45,5 +47,28 @@ defmodule Phoenix.PubSub.DistributedTest do
     refute_received {@node1, :ping}
     :ok = PubSub.direct_broadcast!(@node2, config.pubsub, config.topic, :ping)
     refute_received {@node1, :ping}
+  end
+
+  test "broadcast is received by other node that has running_pool_size > broadcast_pool_size", config do
+    spy_on_pubsub(@node1, config.pubsub, self(), config.topic)
+    # node3 has running_pool_size = 4, broadcast_pool_size = 1
+    spy_on_pubsub(@node3, config.pubsub, self(), config.topic)
+    :ok = PubSub.broadcast(config.pubsub, config.topic, :ping)
+    assert_receive {@node3, :ping}
+  end
+
+  test "broadcast is received by other node that was broadcast from node that has broadcast_pool_size < pool_size", config do
+    # node4 has pool_size = 1, message is sent from node3 that has running_pool_size = 4, broadcast_pool_size = 1
+    spy_on_pubsub(@node1, config.pubsub, self(), config.topic)
+    spy_on_pubsub(@node2, config.pubsub, self(), config.topic)
+    spy_on_pubsub(@node3, config.pubsub, self(), config.topic)
+    spy_on_pubsub(@node4, config.pubsub, self(), config.topic)
+
+    broadcast_from_node(@node3, config.pubsub, config.topic, :ping)
+
+    assert_receive {@node1, :ping}
+    assert_receive {@node2, :ping}
+    assert_receive {@node3, :ping}
+    assert_receive {@node4, :ping}
   end
 end

--- a/test/phoenix/pubsub_test.exs
+++ b/test/phoenix/pubsub_test.exs
@@ -8,5 +8,18 @@ defmodule Phoenix.PubSub.UnitTest do
       assert Exception.message(exception) ==
                "the :name option is required when starting Phoenix.PubSub"
     end
+
+    test "pool_size can't be smaller than broadcast_pool_size" do
+      opts = [name: name(), pool_size: 1, broadcast_pool_size: 2]
+
+      {:error, {{:shutdown, {:failed_to_start_child, Phoenix.PubSub.PG2, message}}, _}} =
+        start_supervised({Phoenix.PubSub, opts})
+
+      assert ^message = "the :pool_size option must be greater than or equal to the :broadcast_pool_size option"
+    end
+
+    defp name do
+      :"#{__MODULE__}_#{:crypto.strong_rand_bytes(8) |> Base.encode16()}"
+    end
   end
 end

--- a/test/support/node_case.ex
+++ b/test/support/node_case.ex
@@ -187,4 +187,10 @@ defmodule Phoenix.PubSub.NodeCase do
       @timeout -> {pid, {:error, :timeout}}
     end
   end
+
+  def broadcast_from_node(node, pubsub, topic, message) do
+    call_node(node, fn ->
+      Phoenix.PubSub.broadcast(pubsub, topic, message)
+    end)
+  end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -3,12 +3,17 @@ Application.put_env(:phoenix_pubsub, :test_adapter, {Phoenix.PubSub.PG2, []})
 exclude = Keyword.get(ExUnit.configuration(), :exclude, [])
 
 Supervisor.start_link(
-  [{Phoenix.PubSub, name: Phoenix.PubSubTest, pool_size: 1}],
+  [{Phoenix.PubSub, name: Phoenix.PubSubTest, pool_size: 4}],
   strategy: :one_for_one
 )
 
 unless :clustered in exclude do
-  Phoenix.PubSub.Cluster.spawn([:"node1@127.0.0.1", :"node2@127.0.0.1"])
+  Phoenix.PubSub.Cluster.spawn([
+    :"node1@127.0.0.1",
+    :"node2@127.0.0.1",
+    {:"node3@127.0.0.1", running_pool_size: 4, broadcast_pool_size: 1},
+    {:"node4@127.0.0.1", pool_size: 1}
+  ])
 end
 
 ExUnit.start()

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -11,7 +11,7 @@ unless :clustered in exclude do
   Phoenix.PubSub.Cluster.spawn([
     :"node1@127.0.0.1",
     :"node2@127.0.0.1",
-    {:"node3@127.0.0.1", running_pool_size: 4, broadcast_pool_size: 1},
+    {:"node3@127.0.0.1", pool_size: 4, broadcast_pool_size: 1},
     {:"node4@127.0.0.1", pool_size: 1}
   ])
 end


### PR DESCRIPTION
👋 
We need to increase the `Phoenix.PubSub`'s `pool_size`; however, we don't see a way to do this safely (i.e., without losing messages during deployment).

For example, if we change the `pool_size: 1` option to `pool_size: 2`, we will encounter a situation where we'll have nodes with both settings running in the cluster. Then, if a message is broadcast from `pool_size: 2`, a message can be sent to the shard number 2 via `pg`. If a node running `pool_size: 1` will receive it, it won't be delivered to its subscribers:

![image](https://github.com/user-attachments/assets/d71c3432-3d84-4fc6-a176-e8bbf9775e7e)

This draft PR attempts to address this issue by introducing a new option, `broadcast_pool_size` (that defaults to `pool_size` if unset). When set, the pool size of shards used for broadcasting messages will be smaller than that used for receiving messages and forwarding them to the local clients.

The pool size change can then be deployed safely in the following two-step process (assuming we're already running our application with `pool_size: 1`):

1. We deploy new version with `pool_size: 2` and `broadcast_pool_size: 1`. The new version has two shards participating in `pg`, but still broadcasts messages using only one shard:
![image](https://github.com/user-attachments/assets/153b1dd2-9081-4e43-ba41-a40dd4aa21ad)
This way, no messages broadcast from node two will be lost.

2. We deploy a new version with `pool_size: 2`. The new version has two shards that can receive and broadcast messages. The version deployed in step 1 can receive messages broadcast by the new version:
![image](https://github.com/user-attachments/assets/ff9c2a2a-705c-48cf-a85a-7fca9256494f)

3. When the deployment from step 2 is complete, all nodes are running pools with the new size:
![image](https://github.com/user-attachments/assets/12716992-6858-4195-82b3-fe83a13b33e5)

If we need to _decrease_ the pool size, we follow the same process but in the reverse order.

I'm opening the PR to discuss this mechanism; we can work on the exact naming of the parameters and documenting the above process in the documentation when the approach is validated.