### PR TITLE
Separate Registry pool size configuration

### DIFF
--- a/lib/phoenix/pubsub/supervisor.ex
+++ b/lib/phoenix/pubsub/supervisor.ex
@@ -22,7 +22,7 @@ defmodule Phoenix.PubSub.Supervisor do
     adapter_name = Module.concat(name, "Adapter")
 
     partitions =
-      opts[:pool_size] ||
+      opts[:registry_pool_size] || opts[:pool_size] ||
         System.schedulers_online() |> Kernel./(4) |> Float.ceil() |> trunc()
 
     registry = [

--- a/test/shared/pubsub_test.exs
+++ b/test/shared/pubsub_test.exs
@@ -41,15 +41,17 @@ defmodule Phoenix.PubSubTest do
 
   setup config do
     size = config[:pool_size] || 1
+    registry_size = config[:registry_pool_size] || config[:pool_size] ||  1
     {adapter, adapter_opts} = Application.get_env(:phoenix_pubsub, :test_adapter)
-    adapter_opts = [adapter: adapter, name: config.test, pool_size: size] ++ adapter_opts
+    adapter_opts = [adapter: adapter, name: config.test, pool_size: size, registry_pool_size: registry_size] ++ adapter_opts
     start_supervised!({Phoenix.PubSub, adapter_opts})
 
     opts = %{
       pubsub: config.test,
       topic: to_string(config.test),
       pool_size: size,
-      node: Phoenix.PubSub.node_name(config.test)
+      node: Phoenix.PubSub.node_name(config.test),
+      adapter_name: Module.concat(config.test, "Adapter")
     }
 
     {:ok, opts}
@@ -173,5 +175,17 @@ defmodule Phoenix.PubSubTest do
       assert_receive {:custom, nil, :none, :direct}
       assert_receive {:custom, :special, :none, :direct}
     end
+  end
+
+  @tag pool_size: 4
+  @tag registry_pool_size: 2
+  test "PubSub pool size can be configured separately from the Registry partitions",
+       config do
+      # This is looking into Registry and PubSub internal implementation, but
+      # i don't know how to test this better.
+      assert {:duplicate, 2, _} = :ets.lookup_element(config.pubsub, -2, 2)
+
+      assert :persistent_term.get(config.adapter_name) ==
+        {config.adapter_name, :"#{config.adapter_name}_2", :"#{config.adapter_name}_3", :"#{config.adapter_name}_4"}
   end
 end


### PR DESCRIPTION
Under our workload (a few thousand topics, single digit to a few thousand subscribers each, a few thousand broadcasts per second from a single node in the cluster), we have started to experience instability of the `PG2Worker` processes (arrival rate > processing rate => message queue growing indefinitely).

We initially approached it by increasing the pool size, but this didn't help much.
After some investigation, we found that introducing more parallelism in processing incoming messages didn't help much because the PG2 worker processes did more work than before.

That's because `Registry` for `:duplicate` keys [is sharded by pids](
https://github.com/elixir-lang/elixir/blob/main/lib/elixir/lib/registry.ex#L1504-L1506), not by key (topic). So, to get all the subscribers, we need to go through all the partitions and get the topic subscribers from each of them.

Moreover, since the dispatch code is executed in the context of the worker process, the serialization cache is valid for just a [single dispatch call](https://github.com/phoenixframework/phoenix/blob/main/lib/phoenix/channel/server.ex#L87-L131).
Even if we fastlane serialization, we might execute it up to the number of partitions.

This PR allows configuring the `Registry` pool size to a value different from the PubSub pool size.
Under our workload, I got the best results with removing the `Registry` pool entirely, i.e., setting `registry_pool_size: 1`.

I'm happy to describe the new option in the documentation, but I'm wondering if there was a particular reason why the `:duplicate` registries are sharded by pids, not by keys. Perhaps that was done to remove contention on the ETS table for topics with many subscribers? Depending on the use case, I can see that picking a sharding method could be a `Registry` configuration option.
