### PR TITLE
Add `Phoenix.PubSub.subscribe_once/3`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 This new version of Phoenix.PubSub provides a simpler, more extensible, and more performant Phoenix.PubSub API. For users of Phoenix.PubSub, the API is the same, although frameworks and other adapters will have to migrate accordingly (which often means less code).
 
-## 2.1.4 (2024-09-27)
+## 2.1.4 (unreleased)
 
 ### Enhancements
   - Add `:permdown_on_shutdown` option.
+  - Add `Phoenix.PubSub.subscribe_once/3`.
 
 ## 2.1.3 (2023-06-14)
 


### PR DESCRIPTION
Given that the possibility of duplicate subscriptions was already discussed in the docs on `subscribe/3`, I assume there's a performance cost to checking for existing subscriptions that callers may not always want to pay. If so, I'd be happy to document that on `subscribe_once/3`. But it seems useful to have this function; I'm looking at a use case where the number of subscriptions to a topic won't be large but duplicate messages would be problematic.

Currently, any caller who wants to avoid duplicate subscriptions would need to use some kind of workaround, such as:

- Avoid calling `subscribe/3` more than once by tracking subscriptions in their own process state, or by checking `Registry.lookup/2` directly (relying on an implementation detail of PubSub)
- Call `unsubscribe/2` each time before calling `subscribe/3`