### PR TITLE
Fix the misattributed root cause of broken tests

### DIFF
--- a/test/shared/pubsub_test.exs
+++ b/test/shared/pubsub_test.exs
@@ -199,11 +199,10 @@ defmodule Phoenix.PubSubTest do
   defp assert_ets_duplicate_count(pubsub, count) do
     result = :ets.lookup_element(pubsub, -2, 2)
 
-    case System.otp_release() do
-      otp when otp >= "28" ->
-        assert {{:duplicate, :pid}, ^count, _} = result
-      _ ->
-        assert {:duplicate, ^count, _} = result
+    if Version.match?(System.version(), ">= 1.19.0") do
+      assert {{:duplicate, :pid}, ^count, _} = result
+    else
+      assert {:duplicate, ^count, _} = result
     end
   end
 end


### PR DESCRIPTION
Although the CI was fixed by #203, the attribution was incorrect. 

The cause should be the Elixir version - [a feature of registry introduced in Elixir v1.19](https://github.com/elixir-lang/elixir/pull/14654), rather than the Erlang/OTP version.

This PR fixes it.