### PR TITLE
fix: s/match_delete/delete_object on Tracker.State

### DIFF
--- a/lib/phoenix/tracker/state.ex
+++ b/lib/phoenix/tracker/state.ex
@@ -355,7 +355,7 @@ defmodule Phoenix.Tracker.State do
     end
 
     for pid <- pids_to_remove do
-      :ets.match_delete(local.pids, pid)
+      :ets.delete_object(local.pids, pid)
     end
 
     true = :ets.insert(local.values, joins)
@@ -513,7 +513,7 @@ defmodule Phoenix.Tracker.State do
 
     foldl(values, nil, ms, fn {topic, pid, key} = values_key, _ ->
       :ets.delete(values, values_key)
-      :ets.match_delete(pids, {pid, topic, key})
+      :ets.delete_object(pids, {pid, topic, key})
       nil
     end)
 


### PR DESCRIPTION
👋 I was looking for ways to optimise Tracker and Tracker.State and noticed that `match_delete` was used where `delete_object` would do the same given that the "pattern" is the exact match.

Claude and I did some pretty basic microbenchmark tests and noticed that delete_object is faster but also uses way less memory.

```elixir 
# Microbenchmark: :ets.match_delete vs :ets.delete_object on a duplicate_bag
# matching the shape of Phoenix.Tracker.State's `pids` table:
#   tuples of {pid, topic, key}, keyed on pid

defmodule EtsBench do
  def fresh_table do
    :ets.new(:bench_pids, [:public, :duplicate_bag])
  end

  def populate(table, n) do
    entries =
      for i <- 1..n do
        {spawn(fn -> :ok end), "topic_#{rem(i, 16)}", "k_#{i}"}
      end

    true = :ets.insert(table, entries)
    entries
  end

  def sample(entries, n) do
    entries |> Enum.shuffle() |> Enum.take(n)
  end

  def setup(table_size, delete_count) do
    table = fresh_table()
    entries = populate(table, table_size)
    targets = sample(entries, delete_count)
    snap = entries
    {table, snap, targets}
  end

  def restore(table, snap) do
    :ets.delete_all_objects(table)
    true = :ets.insert(table, snap)
    :ok
  end
end

inputs = %{
  "1k table / 100 deletes" => EtsBench.setup(1_000, 100),
  "10k table / 100 deletes" => EtsBench.setup(10_000, 100),
  "10k table / 1000 deletes" => EtsBench.setup(10_000, 1_000),
  "50k table / 100 deletes" => EtsBench.setup(50_000, 100),
  "50k table / 1000 deletes" => EtsBench.setup(50_000, 1_000)
}

Benchee.run(
  %{
    "match_delete" => fn {table, targets} ->
      Enum.each(targets, fn entry -> :ets.match_delete(table, entry) end)
    end,
    "delete_object" => fn {table, targets} ->
      Enum.each(targets, fn entry -> :ets.delete_object(table, entry) end)
    end
  },
  inputs: inputs,
  before_each: fn {table, snap, targets} ->
    EtsBench.restore(table, snap)
    {table, targets}
  end,
  warmup: 1,
  time: 5,
  memory_time: 2,
  formatters: [Benchee.Formatters.Console]
)

```


<details open>
<summary>Benchmark results</summary>
Operating System: macOS
CPU Information: Apple M4
Number of Available Cores: 10
Available memory: 32 GB
Elixir 1.18.4
Erlang 27.3.4.6
JIT enabled: true

Benchmark suite executing with the following configuration:
warmup: 1 s
time: 5 s
memory time: 2 s
reduction time: 0 ns
parallel: 1
inputs: 10k table / 100 deletes, 10k table / 1000 deletes, 1k table / 100 deletes, 50k table / 100 deletes, 50k table / 1000 deletes
Estimated total run time: 1 min 20 s


##### With input 10k table / 100 deletes #####
Name                    ips        average  deviation         median         99th %
delete_object      106.14 K        9.42 μs    ±67.96%        8.29 μs       38.10 μs
match_delete        32.89 K       30.41 μs    ±11.66%          30 μs       36.81 μs

Comparison: 
delete_object      106.14 K
match_delete        32.89 K - 3.23x slower +20.99 μs

Memory usage statistics:

Name             Memory usage
delete_object       0.0313 KB
match_delete          4.72 KB - 151.00x memory usage +4.69 KB

**All measurements for memory usage were the same**

##### With input 10k table / 1000 deletes #####
Name                    ips        average  deviation         median         99th %
delete_object       14.86 K       67.30 μs    ±11.18%       68.08 μs       80.20 μs
match_delete         3.38 K      295.46 μs     ±3.63%      295.17 μs      317.91 μs

Comparison: 
delete_object       14.86 K
match_delete         3.38 K - 4.39x slower +228.16 μs

Memory usage statistics:

Name             Memory usage
delete_object       0.0313 KB
match_delete         46.91 KB - 1501.00x memory usage +46.88 KB

**All measurements for memory usage were the same**

##### With input 1k table / 100 deletes #####
Name                    ips        average  deviation         median         99th %
delete_object      184.50 K        5.42 μs    ±17.43%        5.42 μs           7 μs
match_delete        34.91 K       28.65 μs     ±5.28%       28.50 μs       34.08 μs

Comparison: 
delete_object      184.50 K
match_delete        34.91 K - 5.29x slower +23.23 μs

Memory usage statistics:

Name             Memory usage
delete_object       0.0313 KB
match_delete          4.72 KB - 151.00x memory usage +4.69 KB

**All measurements for memory usage were the same**

##### With input 50k table / 100 deletes #####
Name                    ips        average  deviation         median         99th %
delete_object      142.60 K        7.01 μs    ±10.17%        6.96 μs        9.61 μs
match_delete        29.88 K       33.47 μs   ±117.91%          31 μs       47.92 μs

Comparison: 
delete_object      142.60 K
match_delete        29.88 K - 4.77x slower +26.46 μs

Memory usage statistics:

Name             Memory usage
delete_object       0.0313 KB
match_delete          4.72 KB - 151.00x memory usage +4.69 KB

**All measurements for memory usage were the same**

##### With input 50k table / 1000 deletes #####
Name                    ips        average  deviation         median         99th %
delete_object       15.02 K       66.58 μs     ±6.42%       66.21 μs       77.53 μs
match_delete         3.30 K      302.80 μs     ±9.77%      301.08 μs      345.53 μs

Comparison: 
delete_object       15.02 K
match_delete         3.30 K - 4.55x slower +236.22 μs

Memory usage statistics:

Name             Memory usage
delete_object       0.0313 KB
match_delete         46.91 KB - 1501.00x memory usage +46.88 KB

**All measurements for memory usage were the same**
</details>